### PR TITLE
Allow "hypercore" as a valid protocol value

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -183,8 +183,8 @@ function Protocol (opts) {
 util.inherits(Protocol, duplexify)
 
 Protocol.prototype._onhandshake = function (handshake) {
-  if (handshake.protocol !== 'hyperdrive') {
-    return this.destroy(new Error('Protocol must be hyperdrive'))
+  if (handshake.protocol !== 'hyperdrive' && handshake.protocol !== 'hypercore') {
+    return this.destroy(new Error('Protocol must be hyperdrive or hypercore'))
   }
   this.remoteId = handshake.id
   this.emit('handshake')


### PR DESCRIPTION
This will make it easier to rename the protocol to hypercore later.

I'm basing this change on the assumption that eventually hyperdrive is supposed to depend on hypercore, which I'm not sure is true, so this pull request may be misguided.