### PR TITLE
bytesRead progress for single append doesn't currently update

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,6 +312,7 @@ Archive.prototype.append = function (entry, opts, cb) {
   if (opts.filename === true) opts.filename = entry.name
 
   var size = 0
+  var stats = entry.stats
   var feed = this.core.add({filename: opts.filename && path.resolve(this.directory, opts.filename)})
   var stream = pumpify(rabin(), bulk(write, end))
 
@@ -348,6 +349,7 @@ Archive.prototype.append = function (entry, opts, cb) {
   function write (buffers, cb) {
     for (var i = 0; i < buffers.length; i++) {
       size += buffers[i].length
+      stats.bytesRead += buffers[i].length
       self.stats.bytesRead += buffers[i].length
     }
     feed.append(buffers, cb)
@@ -384,6 +386,7 @@ Archive.prototype.appendFile = function (filename, name, cb) {
       name: name,
       mode: st.mode,
       size: 0,
+      stats: stats,
       link: null
     }, {filename: filename}, cb)
 


### PR DESCRIPTION
Thanks for implementing the other stats progress. There was one bug, the bytesRead for a *single append* was stuck at 0, not updating. Currently only the total bytes read is updated (`Archive.stats.bytesRead`). 

This is one way to fix it but there may be a better way to do it. 