### PR TITLE
Copy empty folders and files (#28)

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,9 @@ Archive.prototype.download = function (i, cb) {
     if (!feed) return createEmtpyEntry()
 
     function createEmtpyEntry () {
-      mkdirp(path.dirname(dest), function (err) {
+      var dir = dest
+      if (entry.type === 'file') dir = path.dirname(dest)
+      mkdirp(dir, function (err) {
         if (err) return cb(err)
         if (entry.type !== 'file') return cb(null)
         fs.open(dest, 'a', function (err) {

--- a/index.js
+++ b/index.js
@@ -158,20 +158,7 @@ Archive.prototype.download = function (i, cb) {
     var feed = self._getFeed(entry)
     var dest = join(self.directory, entry.name)
 
-    if (!feed) return createEmtpyEntry()
-
-    function createEmtpyEntry () {
-      var dir = dest
-      if (entry.type === 'file') dir = path.dirname(dest)
-      mkdirp(dir, function (err) {
-        if (err) return cb(err)
-        if (entry.type !== 'file') return cb(null)
-        fs.open(dest, 'a', function (err) {
-          if (err) return cb(err)
-          return cb(null)
-        })
-      })
-    }
+    if (!feed) return createEmptyEntry()
 
     feed.on('put', kick)
     feed.open(kick)
@@ -222,6 +209,19 @@ Archive.prototype.download = function (i, cb) {
       stats.bytesRead = stats.bytesTotal
       stats.end(err)
       cb(err)
+    }
+
+    function createEmptyEntry () {
+      var dir = dest
+      if (entry.type === 'file') dir = path.dirname(dest)
+      mkdirp(dir, function (err) {
+        if (err) return cb(err)
+        if (entry.type !== 'file') return cb(null)
+        fs.open(dest, 'a', function (err, fd) {
+          if (err) return cb(err)
+          fs.close(fd, cb)
+        })
+      })
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -156,6 +156,15 @@ Archive.prototype.download = function (i, cb) {
     if (err) return cb(err)
 
     var feed = self._getFeed(entry)
+    var dest = join(self.directory, entry.name)
+    if (!feed && entry.type === 'file') {
+      mkdirp(path.dirname(dest), function () {
+        fs.open(dest, 'a', function (err) {
+          if (err) return cb(err)
+          return cb(null)
+        })
+      })
+    }
     if (!feed) return cb(null)
 
     feed.on('put', kick)
@@ -187,7 +196,6 @@ Archive.prototype.download = function (i, cb) {
         if (!feed.has(ptr)) return
       }
 
-      var dest = join(self.directory, entry.name)
       if (process.browser) return done()
 
       fs.stat(dest, function (_, st) {

--- a/index.js
+++ b/index.js
@@ -157,15 +157,19 @@ Archive.prototype.download = function (i, cb) {
 
     var feed = self._getFeed(entry)
     var dest = join(self.directory, entry.name)
-    if (!feed && entry.type === 'file') {
-      mkdirp(path.dirname(dest), function () {
+
+    if (!feed) return createEmtpyEntry()
+
+    function createEmtpyEntry () {
+      mkdirp(path.dirname(dest), function (err) {
+        if (err) return cb(err)
+        if (entry.type !== 'file') return cb(null)
         fs.open(dest, 'a', function (err) {
           if (err) return cb(err)
           return cb(null)
         })
       })
     }
-    if (!feed) return cb(null)
 
     feed.on('put', kick)
     feed.open(kick)

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -3,6 +3,7 @@ var memdb = require('memdb')
 var os = require('os')
 var path = require('path')
 var fs = require('fs')
+var mkdirp = require('mkdirp')
 var hyperdrive = require('../')
 
 tape('replicates file', function (t) {
@@ -38,4 +39,54 @@ tape('replicates file', function (t) {
       p1.pipe(p2).pipe(p1)
     })
   })
+})
+
+tape('replicates empty files', function (t) {
+  var drive = hyperdrive(memdb())
+  var driveClone = hyperdrive(memdb())
+
+  var tmp = path.join(os.tmpdir(), 'hyperdrive-' + process.pid + '-' + Date.now())
+  var emptyFile = path.join(tmp, 'empty.txt')
+
+  mkdirp(path.dirname(emptyFile), function (err) {
+    if (err) throw err
+    fs.open(emptyFile, 'a', function (err) {
+      if (err) throw err
+      appendFile()
+    })
+  })
+
+  var archive = drive.add(tmp)
+
+  function appendFile () {
+    archive.appendFile(emptyFile, 'empty.txt', function (err) {
+      t.error(err, 'no error')
+      archive.finalize(function (err) {
+        t.error(err, 'no error')
+
+        var tmp2 = path.join(os.tmpdir(), 'hyperdrive-2-' + process.pid + '-' + Date.now())
+        var clone = driveClone.get(archive.id, tmp2)
+
+        clone.download(0, function () {
+          clone.createFileStream(0)
+            .on('data', function (data) {
+
+            })
+            .on('end', function () {
+              t.same(
+                fs.readFileSync(emptyFile),
+                fs.readFileSync(path.join(tmp2, 'empty.txt')),
+                'empty file copied over'
+              )
+              t.end()
+            })
+        })
+
+        var p1 = drive.createPeerStream()
+        var p2 = driveClone.createPeerStream()
+
+        p1.pipe(p2).pipe(p1)
+      })
+    })
+  }
 })

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -50,9 +50,9 @@ tape('replicates empty files', function (t) {
 
   mkdirp(path.dirname(emptyFile), function (err) {
     if (err) throw err
-    fs.open(emptyFile, 'a', function (err) {
+    fs.open(emptyFile, 'a', function (err, fd) {
       if (err) throw err
-      appendFile()
+      fs.close(fd, appendFile)
     })
   })
 
@@ -79,6 +79,52 @@ tape('replicates empty files', function (t) {
                 'empty file copied over'
               )
               t.end()
+            })
+        })
+
+        var p1 = drive.createPeerStream()
+        var p2 = driveClone.createPeerStream()
+
+        p1.pipe(p2).pipe(p1)
+      })
+    })
+  }
+})
+
+tape('replicates empty directories', function (t) {
+  var drive = hyperdrive(memdb())
+  var driveClone = hyperdrive(memdb())
+
+  var tmp = path.join(os.tmpdir(), 'hyperdrive-' + process.pid + '-' + Date.now())
+  var emptyDir = path.join(tmp, 'empty')
+
+  mkdirp(emptyDir, function (err) {
+    if (err) throw err
+    appendDir()
+  })
+
+  var archive = drive.add(tmp)
+
+  function appendDir () {
+    archive.appendFile(emptyDir, 'empty', function (err) {
+      t.error(err, 'no error')
+      archive.finalize(function (err) {
+        t.error(err, 'no error')
+
+        var tmp2 = path.join(os.tmpdir(), 'hyperdrive-2-' + process.pid + '-' + Date.now())
+        var clone = driveClone.get(archive.id, tmp2)
+
+        clone.download(0, function () {
+          clone.createFileStream(0)
+            .on('data', function (data) {
+              // nothing to do with empty dirs
+            })
+            .on('end', function () {
+              fs.stat(path.join(tmp2, 'empty'), function (err, stats) {
+                t.error(err, 'no stats error')
+                t.ok(stats, 'empty dir copied')
+                t.end()
+              })
             })
         })
 


### PR DESCRIPTION
Fixes empty file and directory bug (#28)

I added one test for the empty file. I was having trouble testing the empty directory issue though - can you run `appendFile` on a directory somehow?