### PR TITLE
Allows strings as the hex link to hyperdrive.get see #29

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ Hyperdrive.prototype.createPeerStream = function () {
 
 Hyperdrive.prototype.get = function (id, folder) {
   if (!folder || !id) throw new Error('id and folder required')
+  id = new Buffer(id, 'hex')
   return new Archive(this, folder, id)
 }
 

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -18,7 +18,10 @@ tape('replicates file', function (t) {
       t.error(err, 'no error')
 
       var tmp = path.join(os.tmpdir(), 'hyperdrive-' + process.pid + '-' + Date.now())
-      var clone = driveClone.get(archive.id, tmp)
+
+      // to make sure .get can take plain string link
+      var link = archive.id.toString('hex')
+      var clone = driveClone.get(link, tmp)
 
       clone.download(0, function () {
         var buf = []


### PR DESCRIPTION
This covers the third bullet on #29