### PR TITLE
guard against null content

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
   }
 
   function end (cb) {
-    entry.blocks = self.content.blocks - start
+    entry.blocks = (self.content ? self.content.blocks : 0) - start
     if (self.options.storage) self.options.storage.closeAppend(done)
     else done(null)
 


### PR DESCRIPTION
This was difficult to create a failing test for, but in my tests for another package upstream I was consistently getting errors:

```
/home/substack/projects/osm-p2p-observations/node_modules/hyperdrive/index.js:260
    entry.blocks = self.content.blocks - start
                               ^

TypeError: Cannot read property 'blocks' of null
    at end [as _flush] (/home/substack/projects/osm-p2p-observations/node_modules/hyperdrive/index.js:260:32)
    at Bulk._write (/home/substack/projects/osm-p2p-observations/node_modules/bulk-write-stream/index.js:47:35)
    at doWrite (/home/substack/projects/osm-p2p-observations/node_modules/bulk-write-stream/node_modules/readable-stream/lib/_stream_writable.js:279:12)
    at writeOrBuffer (/home/substack/projects/osm-p2p-observations/node_modules/bulk-write-stream/node_modules/readable-stream/lib/_stream_writable.js:266:5)
    at Writable.write (/home/substack/projects/osm-p2p-observations/node_modules/bulk-write-stream/node_modules/readable-stream/lib/_stream_writable.js:211:11)
    at Bulk.end (/home/substack/projects/osm-p2p-observations/node_modules/bulk-write-stream/index.js:35:41)
    at Rabin.onend (/home/substack/projects/osm-p2p-observations/node_modules/readable-stream/lib/_stream_readable.js:495:10)
    at Rabin.g (events.js:273:16)
    at emitNone (events.js:85:20)
    at Rabin.emit (events.js:179:7)
```

This patch fixes that issue.