### PR TITLE
list() offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,14 @@ Emitted every time a piece of data is downloaded
 
 Emitted every time a piece of data is uploaded
 
-#### `var rs = archive.list()`
+#### `var rs = archive.list(opts={}, cb)`
 
 Returns a readable stream of all entries in the archive.
+
+* `opts.offset` - start streaming from this offset (default: 0)
+* `opts.live` - keep the stream open as new updates arrive (default: false)
+
+You can collect the results of the stream with `cb(err, entries)`.
 
 #### `var rs = archive.createFileReadStream(entry)`
 

--- a/archive.js
+++ b/archive.js
@@ -71,7 +71,7 @@ Archive.prototype.list = function (opts, cb) {
 
   var self = this
   var opened = false
-  var offset = 0
+  var offset = opts.offset || 0
   var live = opts.live === false ? false : (opts.live || !cb)
 
   return collect(from.obj(read), cb)

--- a/test/misc.js
+++ b/test/misc.js
@@ -29,6 +29,38 @@ tape('list', function (t) {
   })
 })
 
+tape('list offset', function (t) {
+  t.plan(10)
+  var drive = hyperdrive(memdb())
+
+  var archive = drive.createArchive({
+    file: function (name) {
+      return raf(path.join(__dirname, name), {readable: true, writable: false})
+    }
+  })
+
+  archive.append('misc.js')
+  archive.append('replicates.js')
+  archive.append('overwrite.js')
+
+  archive.finalize(function () {
+    archive.list({ offset: 1 }, function (err, list) {
+      t.error(err, 'no error')
+      t.same(list.length, 2, 'two entries with offset: 1')
+      t.same(list[0].type, 'file')
+      t.same(list[0].name, 'replicates.js')
+      t.same(list[1].type, 'file')
+      t.same(list[1].name, 'overwrite.js')
+    })
+    archive.list({ offset: 2 }, function (err, list) {
+      t.error(err, 'no error')
+      t.same(list.length, 1, 'one entry with offset: 2')
+      t.same(list[0].type, 'file')
+      t.same(list[0].name, 'overwrite.js')
+    })
+  })
+})
+
 tape('download file', function (t) {
   var drive = hyperdrive(memdb())
   var driveClone = hyperdrive(memdb())


### PR DESCRIPTION
This patch allows `archive.list()` to accept an `opts.offset` parameter instead of the default value of `0`. This way, I can more easily write a hyperdrive indexer that tails the internal feed without having to implement the machinery already defined in `.list()`.