### PR TITLE
Adding entry.content with bytesOffset and blockOffet

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -48,7 +48,7 @@ inherits(Archive, events.EventEmitter)
 
 Archive.prototype.replicate = function (opts) {
   if (!opts) opts = {}
-  assertRepliction(this)
+  assertReplication(this)
 
   var stream = isStream(opts) ? opts : opts.stream
   var self = this
@@ -472,7 +472,7 @@ function fileReadStream (store) {
   }
 }
 
-function assertRepliction (self) {
+function assertReplication (self) {
   if (!self.key) throw new Error('Finalize the archive before replicating it')
 }
 

--- a/archive.js
+++ b/archive.js
@@ -189,7 +189,7 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
   var self = this
   var opened = false
   var start = 0
-  var byteOffset = this.content.bytes
+  var bytesOffset = 0
   var stream = pumpify(rabin(), bulk.obj(write, end))
 
   entry.length = 0
@@ -221,6 +221,7 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
         })
       } else {
         start = self.content.blocks
+        bytesOffset = self.content.bytes
         if (self.options.storage) {
           self.options.storage.openAppend(entry.name, opts.indexing)
         }
@@ -245,7 +246,7 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
       if (err) return cb(err)
 
       entry.content = {
-        byteOffset: byteOffset,
+        bytesOffset: bytesOffset,
         blockOffset: start
       }
       entry.blocks = self.content.blocks - start
@@ -309,7 +310,7 @@ Archive.prototype.append = function (entry, cb) {
       entry.length = 0
       entry.blocks = 0
       entry.content = {
-        byteOffset: self.content.bytes,
+        bytesOffset: self.content.bytes,
         blockOffset: self.content.blocks
       }
       self._writeEntry(entry, cb)

--- a/archive.js
+++ b/archive.js
@@ -189,6 +189,7 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
   var self = this
   var opened = false
   var start = 0
+  var byteOffset = this.content.bytes
   var stream = pumpify(rabin(), bulk.obj(write, end))
 
   entry.length = 0
@@ -243,6 +244,10 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
     function done (err) {
       if (err) return cb(err)
 
+      entry.content = {
+        byteOffset: byteOffset,
+        blockOffset: start
+      }
       entry.blocks = self.content.blocks - start
       if (self.options.storage) self.options.storage.closeAppend(done)
       else done(null)
@@ -303,6 +308,10 @@ Archive.prototype.append = function (entry, cb) {
       // user messing them up
       entry.length = 0
       entry.blocks = 0
+      entry.content = {
+        byteOffset: self.content.bytes
+        blockOffset: self.content.blocks
+      }
       self._writeEntry(entry, cb)
     }
   })

--- a/archive.js
+++ b/archive.js
@@ -309,7 +309,7 @@ Archive.prototype.append = function (entry, cb) {
       entry.length = 0
       entry.blocks = 0
       entry.content = {
-        byteOffset: self.content.bytes
+        byteOffset: self.content.bytes,
         blockOffset: self.content.blocks
       }
       self._writeEntry(entry, cb)

--- a/test/misc.js
+++ b/test/misc.js
@@ -93,7 +93,7 @@ tape('download file', function (t) {
   })
 })
 
-tape('byte/block offsets with one file', function (t) {
+tape('bytes/block offsets with one file', function (t) {
   var drive = hyperdrive(memdb())
   var archive = drive.createArchive({
     file: function (name) {
@@ -114,7 +114,7 @@ tape('byte/block offsets with one file', function (t) {
   })
 })
 
-tape('byte/block offsets with two files', function (t) {
+tape('bytes/block offsets with two files', function (t) {
   var drive = hyperdrive(memdb())
   var archive = drive.createArchive({
     file: function (name) {

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,3 +1,4 @@
+var fs = require('fs')
 var tape = require('tape')
 var memdb = require('memdb')
 var path = require('path')
@@ -12,7 +13,6 @@ tape('list', function (t) {
       return raf(path.join(__dirname, name), {readable: true, writable: false})
     }
   })
-
   archive.append('misc.js')
   archive.append('replicates.js')
 
@@ -90,6 +90,54 @@ tape('download file', function (t) {
     var streamClone = clone.replicate()
 
     stream.pipe(streamClone).pipe(stream)
+  })
+})
+
+tape('byte/block offsets with one file', function (t) {
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive({
+    file: function (name) {
+      return raf(path.join(__dirname, name), {readable: true, writable: false})
+    }
+  })
+
+  archive.append('misc.js', function (err) {
+    t.error(err, 'no error')
+    archive.list(function (err, entries) {
+      t.error(err, 'no error')
+      t.same(entries.length, 1, 'one entry')
+      t.same(entries[0].content.blockOffset, 0, 'block offset is 0')
+      t.same(entries[0].content.bytesOffset, 0, 'bytes offset is 0')
+      t.pass('single-file bytes/block offset is correct')
+      t.end()
+    })
+  })
+})
+
+tape('byte/block offsets with two files', function (t) {
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive({
+    file: function (name) {
+      return raf(path.join(__dirname, name), {readable: true, writable: false})
+    }
+  })
+
+  var correctBytes = fs.readFileSync(path.join(__dirname, 'misc.js')).length
+
+  archive.append('misc.js', function (err) {
+    t.error(err, 'no error')
+    var correctBlocks = archive.content.blocks
+    archive.append('misc.js', function (err) {
+      t.error(err, 'no error')
+      archive.list(function (err, entries) {
+        t.error(err, 'no error')
+        t.same(entries.length, 2, 'two entries')
+        t.same(entries[1].content.bytesOffset, correctBytes, 'correct offset')
+        t.same(entries[1].content.blockOffset, correctBlocks, 'correct blocks')
+        t.pass('two files bytes/blocks offset is correct')
+        t.end()
+      })
+    })
   })
 })
 


### PR DESCRIPTION
When a new entry is added to an archive, the `content` field of the entry message is populated with that entry's `bytesOffset` and `blockOffset` -- just pulled from the the hypercore on insertion. 

Added a few tests for archives containing one and two files in `test/misc.js`. 