### PR TITLE
make createByteCursor synchronous

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -262,12 +262,8 @@ Archive.prototype.createFileWriteStream = function (entry, opts) {
   }
 }
 
-Archive.prototype.createByteCursor = function (entry, offset, cb) {
-  var self = this
-  this.get(entry, function (err, result) {
-    if (err) return cb(err)
-    return cb(null, cursor(result, self.content, offset))
-  })
+Archive.prototype.createByteCursor = function (index, offset, cb) {
+  return cursor(this, index, offset)
 }
 
 Archive.prototype.createFileReadStream = function (entry) {

--- a/cursor.js
+++ b/cursor.js
@@ -1,27 +1,36 @@
 module.exports = Cursor
 
-function Cursor (entry, content, offset) {
-  if (!(this instanceof Cursor)) return new Cursor(entry, content, offset)
-  this.entry = entry
-  this.content = content
+function Cursor (archive, index, offset) {
+  if (!(this instanceof Cursor)) return new Cursor(archive, index, offset)
+  this.archive = archive
+  this.index = index
   this._position = offset
-  this._bytesOffset = entry.content.bytesOffset + offset
+  this._entry = null
+  this._bytesOffset = null
 }
 
 Cursor.prototype.next = function (cb) {
   var self = this
-  if (this._position > this.entry.length - 1) {
-    return cb(null, null)
-  }
-  this.content.seek(this._bytesOffset, function (err, index, offset) {
-    if (err) return cb(err)
-    self.content.get(index, function (err, data) {
+  if (!this._entry) {
+    this.archive.get(this.index, function (err, entry) {
       if (err) return cb(err)
-      var sliced = data.slice(offset)
-      self._bytesOffset += sliced.length
-      self._position += sliced.length
-      return cb(null, sliced)
+      self._entry = entry
+      self._bytesOffset = entry.content.bytesOffset + self._position
+      return self.next(cb)
     })
-  })
+  } else if (this._position > this._entry.length - 1) {
+    return cb(null, null)
+  } else {
+    this.archive.content.seek(this._bytesOffset, function (err, index, offset) {
+      if (err) return cb(err)
+      self.archive.content.get(index, function (err, data) {
+        if (err) return cb(err)
+        var sliced = data.slice(offset)
+        self._bytesOffset += sliced.length
+        self._position += sliced.length
+        return cb(null, sliced)
+      })
+    })
+  }
 }
 

--- a/test/rw.js
+++ b/test/rw.js
@@ -25,15 +25,13 @@ test('random access read in-bounds', function (t) {
 
   archive.createFileWriteStream('hello.txt').end(testString)
   archive.finalize(function () {
-    archive.createByteCursor('hello.txt', 0, function (err, cursor) {
+    var cursor = archive.createByteCursor('hello.txt', 0)
+    cursor.next(function (err, data) {
       t.error(err, 'no error')
-      cursor.next(function (err, data) {
-        t.error(err, 'no error')
-        t.notEquals(data, null, 'data is not null')
-        t.same(data.length, 10, 'data length is valid')
-        t.pass('in-bounds random access read passes')
-        t.end()
-      })
+      t.notEquals(data, null, 'data is not null')
+      t.same(data.length, 10, 'data length is valid')
+      t.pass('in-bounds random access read passes')
+      t.end()
     })
   })
 })
@@ -46,18 +44,16 @@ test('random access read no more data', function (t) {
 
   archive.createFileWriteStream('hello.txt').end(testString)
   archive.finalize(function () {
-    archive.createByteCursor('hello.txt', 5, function (err, cursor) {
+    var cursor = archive.createByteCursor('hello.txt', 5)
+    cursor.next(function (err, data) {
       t.error(err, 'no error')
+      t.notEquals(data, null, 'data is not null')
+      t.same(data.length, 5, 'data length is valid')
       cursor.next(function (err, data) {
         t.error(err, 'no error')
-        t.notEquals(data, null, 'data is not null')
-        t.same(data.length, 5, 'data length is valid')
-        cursor.next(function (err, data) {
-          t.error(err, 'no error')
-          t.equals(data, null, 'returns null when data is not available')
-          t.pass('random access read passes when no more data is available')
-          t.end()
-        })
+        t.equals(data, null, 'returns null when data is not available')
+        t.pass('random access read passes when no more data is available')
+        t.end()
       })
     })
   })
@@ -72,18 +68,16 @@ test('random access read with two files', function (t) {
   archive.createFileWriteStream('hello.txt').end(testString)
   archive.createFileWriteStream('world.txt').end(testString)
   archive.finalize(function () {
-    archive.createByteCursor('hello.txt', 0, function (err, cursor) {
+    var cursor = archive.createByteCursor('hello.txt', 0)
+    cursor.next(function (err, data) {
       t.error(err, 'no error')
+      t.notEquals(data, null, 'data is not null')
+      t.same(data.length, 10, 'data length is valid')
       cursor.next(function (err, data) {
         t.error(err, 'no error')
-        t.notEquals(data, null, 'data is not null')
-        t.same(data.length, 10, 'data length is valid')
-        cursor.next(function (err, data) {
-          t.error(err, 'no error')
-          t.equals(data, null, 'returns null when file boundary is reached')
-          t.pass('random access read passes when file boundary is reached')
-          t.end()
-        })
+        t.equals(data, null, 'returns null when file boundary is reached')
+        t.pass('random access read passes when file boundary is reached')
+        t.end()
       })
     })
   })
@@ -112,16 +106,14 @@ test('random access read spanning multiple blocks', function (t) {
 
   archive.createFileWriteStream('hello.txt').end(testBuffer)
   archive.finalize(function () {
-    archive.createByteCursor('hello.txt', 0, function (err, cursor) {
+    var cursor = archive.createByteCursor('hello.txt', 0)
+    archive.get('hello.txt', function (err, entry) {
+      console.log('entry.blocks', entry.blocks)
       t.error(err, 'no error')
-      archive.get('hello.txt', function (err, entry) {
-        console.log('entry.blocks', entry.blocks)
-        t.error(err, 'no error')
-        verifyBlock(0, cursor, archive.content, function () {
-          verifyBlock(1, cursor, archive.content, function () {
-            t.pass('cursor data is always the same as block data')
-            t.end()
-          })
+      verifyBlock(0, cursor, archive.content, function () {
+        verifyBlock(1, cursor, archive.content, function () {
+          t.pass('cursor data is always the same as block data')
+          t.end()
         })
       })
     })
@@ -138,17 +130,15 @@ test('random access read with offset', function (t) {
   archive.createFileWriteStream('hello.txt').end(testString1)
   archive.createFileWriteStream('world.txt').end(testString2)
   archive.finalize(function () {
-    archive.createByteCursor('world.txt', 5, function (err, cursor) {
+    var cursor = archive.createByteCursor('world.txt', 5)
+    cursor.next(function (err, data) {
       t.error(err, 'no error')
+      t.same(data.toString('utf8'), 'BEEP\n', 'data at offset equals BEEP')
       cursor.next(function (err, data) {
         t.error(err, 'no error')
-        t.same(data.toString('utf8'), 'BEEP\n', 'data at offset equals BEEP')
-        cursor.next(function (err, data) {
-          t.error(err, 'no error')
-          t.equals(data, null, 'returns null when file boundary is reached')
-          t.pass('random access read passes with nonzero starting offset')
-          t.end()
-        })
+        t.equals(data, null, 'returns null when file boundary is reached')
+        t.pass('random access read passes with nonzero starting offset')
+        t.end()
       })
     })
   })
@@ -162,14 +152,12 @@ test('random access read with huge first offset', function (t) {
 
   archive.createFileWriteStream('hello.txt').end(testString1)
   archive.finalize(function () {
-    archive.createByteCursor('hello.txt', 5000000, function (err, cursor) {
+    var cursor = archive.createByteCursor('hello.txt', 5000000)
+    cursor.next(function (err, data) {
       t.error(err, 'no error')
-      cursor.next(function (err, data) {
-        t.error(err, 'no error')
-        t.same(data, null, 'data for huge offset should be null')
-        t.pass('next returned null for large offset')
-        t.end()
-      })
+      t.same(data, null, 'data for huge offset should be null')
+      t.pass('next returned null for large offset')
+      t.end()
     })
   })
 })


### PR DESCRIPTION
This PR changes createByteCursor into a synchronous call that will asynchronously get an entry out of the archive the first time `next()` is called.

@mafintosh this look better? It's certainly been easier to work with so far. 