### PR TITLE
checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ Options include
 
 Pipe this stream together with another peer that is interested in the same archive to replicate the content.
 
+#### `var subArchive = archive.checkout(hashOrBlock)`
+
+Create a read-only sub-archive rooted at a rolling hash buffer or block index.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "rabin": "^1.4.0",
     "stream-collector": "^1.0.1",
     "through2": "^2.0.1",
-    "thunky": "^0.1.0"
+    "thunky": "^0.1.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "concat-stream": "^1.5.1",

--- a/test/checkout.js
+++ b/test/checkout.js
@@ -1,0 +1,55 @@
+var test = require('tape')
+var hyperdrive = require('../')
+var memdb = require('memdb')
+var concat = require('concat-stream')
+
+test('checkout', function (t) {
+  var contents = [
+    { 'hello.txt': 'HI' },
+    { 'hello.txt': 'HELLO', 'msg.txt': 'WHAT' },
+    { 'hello.txt': 'HEY', 'msg.txt': 'SMITHEREENS' },
+    { 'hello.txt': 'HOWDY', 'msg.txt': 'AMETHYST' }
+  ]
+  t.plan(11)
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive(undefined, { live: true })
+  var hashes = []
+  ;(function next (i) {
+    if (i === contents.length) return ready()
+    var files = contents[i]
+    var pending = 1
+    Object.keys(files).forEach(function (file) {
+      pending++
+      var w = archive.createFileWriteStream(file)
+      w.end(files[file])
+      w.once('finish', function () {
+        if (--pending === 0) done()
+      })
+    })
+    if (--pending === 0) done()
+
+    function done () {
+      archive.metadata.head(function (err, hash) {
+        t.error(err)
+        hashes.push(hash)
+        next(i + 1)
+      })
+    }
+  })(0)
+
+  function ready () {
+    hashes.forEach(function (hash, i) {
+      var ch = archive.checkout(hash)
+      verify(ch, contents[i], hash.toString('hex'))
+    })
+  }
+
+  function verify (ch, files, hash) {
+    Object.keys(files).forEach(function (file) {
+      var r = ch.createFileReadStream(file)
+      r.pipe(concat({ encoding: 'string' }, function (body) {
+        t.equal(body, files[file], 'verify ' + hash + ':' + file)
+      }))
+    })
+  }
+})


### PR DESCRIPTION
This patch implements `archive.checkout(hashOrBlock)`, which returns a read-only sub-archive rooted at a rolling root hash or block.

depends on https://github.com/mafintosh/hypercore/pull/30