### PR TITLE
Add file and download-finished events (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ Emitted every time a piece of data is downloaded
 
 Emitted every time a piece of data is uploaded
 
+#### `archive.on('file-download-finished', entry)`
+
+Emitted every time an entry is downloaded
+
+#### `archive.on('download-finished')`
+
+Emitted when archive is finished downloading. Will also fire when live archive updates finish.
+
+#### `archive.on('finalized')`
+
+Emitted when archive is finalized after `archive.finalize` call. Emitted when `archive.finalize` cb() is called.
+
 #### `var rs = archive.list(opts={}, cb)`
 
 Returns a readable stream of all entries in the archive.

--- a/archive.js
+++ b/archive.js
@@ -178,6 +178,7 @@ Archive.prototype.finalize = function (cb) {
     if (err) return cb(err)
     self.key = self.metadata.key
     self.discoveryKey = self.metadata.discoveryKey
+    self.emit('finalized')
     cb(null)
   }
 }
@@ -367,6 +368,7 @@ Archive.prototype.download = function (entry, cb) {
     }
 
     function done () {
+      self.emit('file-download-finished', entry)
       self.content.removeListener('download', kick)
       cb()
     }
@@ -451,6 +453,10 @@ Archive.prototype._open = function (cb) {
 
     self.content.on('upload', function (block, data) {
       self.emit('upload', data)
+    })
+
+    self.content.on('download-finished', function () {
+      self.emit('download-finished')
     })
 
     if (self.metadata.live && !index) self._writeIndex(opened)


### PR DESCRIPTION
### New Events:
- `file-downloaded`
- `file-appended`
- `download-finished`
- `finalized`

Plus docs and event tests.

@mafintosh before you suggested: 

>  good pr would be to add file-download, file-upload, file-downloaded events

What's the difference b/t file-download and file-downloaded? And what would someone use file-upload event for (or did you mean file-appended)? 
