### PR TITLE
skip extra entry lookups in _range

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -389,6 +389,11 @@ Archive.prototype._range = function (entry, cb) {
   var startBlock = 0
   var self = this
 
+  if (entry && entry.content && entry.blocks !== undefined) {
+    return process.nextTick(function () {
+      cb(null, entry.content.blockOffset, entry.content.blockOffset + entry.blocks, entry)
+    })
+  }
   this.get(entry, function (err, result) {
     if (err) return cb(err)
 

--- a/test/rw.js
+++ b/test/rw.js
@@ -205,3 +205,44 @@ test('write and read after replication', function (t) {
     r.pipe(archive.replicate()).pipe(r)
   })
 })
+
+test.only('read previous entries', function (t) {
+  t.plan(5)
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive(null, { live: true })
+  var data = [
+    { 'hello.txt': 'HI' },
+    { 'hello.txt': 'WHAT', 'index.html': '<h1>hey</h1>' },
+    { 'hello.txt': '!' }
+  ]
+  var expected = [
+    { name: 'hello.txt', body: 'HI' },
+    { name: 'hello.txt', body: 'WHAT' },
+    { name: 'index.html', body: '<h1>hey</h1>' },
+    { name: 'hello.txt', body: '!' }
+  ]
+  ;(function next () {
+    if (data.length === 0) return check()
+    var files = data.shift()
+    var pending = 1
+    Object.keys(files).forEach(function (key) {
+      pending++
+      archive.createFileWriteStream(key)
+        .once('finish', done)
+        .end(files[key])
+    })
+    done()
+    function done () { if (--pending === 0) next() }
+  })()
+  function check () {
+    archive.list({ live: false }, function (err, files) {
+      t.error(err)
+      files.forEach(function (file) {
+        archive.createFileReadStream(file).pipe(concat(function (body) {
+          var e = expected.shift()
+          t.equal(body.toString(), e.body, e.name)
+        }))
+      })
+    })
+  }
+})

--- a/test/rw.js
+++ b/test/rw.js
@@ -238,8 +238,8 @@ test('read previous entries', function (t) {
     archive.list({ live: false }, function (err, files) {
       t.error(err)
       files.forEach(function (file) {
+        var e = expected.shift()
         archive.createFileReadStream(file).pipe(concat(function (body) {
-          var e = expected.shift()
           t.equal(body.toString(), e.body, e.name)
         }))
       })

--- a/test/rw.js
+++ b/test/rw.js
@@ -206,7 +206,7 @@ test('write and read after replication', function (t) {
   })
 })
 
-test.only('read previous entries', function (t) {
+test('read previous entries', function (t) {
   t.plan(5)
   var drive = hyperdrive(memdb())
   var archive = drive.createArchive(null, { live: true })


### PR DESCRIPTION
This patch skips the extra recursive lookup in `_range()` for objects which are already entries. This means methods that use `_range` such as `createFileReadStream()` can stream the data from previous documents, not only the latest document.