### PR TITLE
Add archive.countDownloadedBlocks and archive.isEntryDownloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,20 @@ Options include:
 }
 ```
 
+#### `archive.countDownloadedBlocks(entry)`
+
+Count the number of blocks in the entry that have been downloaded.
+You can calculate the file's download progress, as a percentage, with:
+
+```js
+var downloaded = archive.countDownloadedBlocks(entry)
+var progress =  downloaded / entry.blocks
+```
+
+#### `archive.isEntryDownloaded(entry)`
+
+Has all of the entry's blocks been downloaded?
+
 ## License
 
 MIT

--- a/archive.js
+++ b/archive.js
@@ -151,6 +151,27 @@ Archive.prototype.lookup = function (name, cb) {
   }
 }
 
+Archive.prototype.countDownloadedBlocks = function (entry) {
+  // no content hypercore yet? then nothing is downloaded
+  if (!this.content) {
+    return 0
+  }
+
+  // iterate and tally the entry's blocks
+  var b = 0
+  var offset = entry.content.blockOffset
+  for (var i = 0; i < entry.blocks; i++) {
+    if (this.content.has(i + offset)) {
+      b++
+    }
+  }
+  return b
+}
+
+Archive.prototype.isEntryDownloaded = function (entry) {
+  return this.countDownloadedBlocks(entry) === entry.blocks
+}
+
 Archive.prototype.finalize = function (cb) {
   if (!cb) cb = noop
   var self = this


### PR DESCRIPTION
Closes #97 and adds 2 new methods. From the readme:

---

#### `archive.countDownloadedBlocks(entry)`

Count the number of blocks in the entry that have been downloaded.
You can calculate the file's download progress, as a percentage, with:

```js
var downloaded = archive.countDownloadedBlocks(entry)
var progress =  downloaded / entry.blocks
```

#### `archive.isEntryDownloaded(entry)`

Has all of the entry's blocks been downloaded?