### PR TITLE
Add .unlink() and .history()

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,20 @@ Emitted every time a piece of data is downloaded
 
 Emitted every time a piece of data is uploaded
 
-#### `var rs = archive.list(opts={}, cb)`
+#### `var rs = archive.history(opts={}, cb)`
 
-Returns a readable stream of all entries in the archive.
+Returns a readable stream of the history of the entries in the archive.
 
 * `opts.offset` - start streaming from this offset (default: 0)
 * `opts.live` - keep the stream open as new updates arrive (default: false)
+
+You can collect the results of the stream with `cb(err, entries)`.
+
+#### `var rs = archive.list(opts={}, cb)`
+
+Returns a readable stream of all current entries in the archive.
+
+* `opts.offset` - start streaming from this offset (default: 0)
 
 You can collect the results of the stream with `cb(err, entries)`.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ archive.append('hello.txt', function () {
 })
 ```
 
+#### `archive.unlink(entry, callback)`
+
+Remove an entry from the archive. Only possible if this is an live archive you originally created
+or an unfinalized archive.
+
+This will not affect the files on the disk, even if you set the file option in the archive constructor.
+
 #### `archive.finalize([callback])`
 
 Finalize the archive. You need to do this before sharing it if the archive is not live (it is live per default).

--- a/archive.js
+++ b/archive.js
@@ -486,7 +486,7 @@ Archive.prototype._range = function (entry, cb) {
   }
   this.get(entry, function (err, result) {
     if (err) return cb(err)
-    if (result.type == 'unlink') {
+    if (result.type === 'unlink') {
       err = new Error('File was unlinked')
       err.fileWasUnlinked = true
       err.fileName = result.name

--- a/schema.proto
+++ b/schema.proto
@@ -20,9 +20,9 @@ message Entry {
   optional Content content = 10;
 }
 
-// message Unlink {
-//  required string name = 1;
-//}
+message Unlink {
+  required string name = 1;
+}
 
 // message Rename {
 //  required string source = 1;

--- a/test/misc.js
+++ b/test/misc.js
@@ -105,7 +105,7 @@ tape('bytes/block offsets with one file', function (t) {
 
   archive.append('misc.js', function (err) {
     t.error(err, 'no error')
-    archive.list(function (err, entries) {
+    archive.history(function (err, entries) {
       t.error(err, 'no error')
       t.same(entries.length, 1, 'one entry')
       t.same(entries[0].content.blockOffset, 0, 'block offset is 0')
@@ -131,7 +131,7 @@ tape('bytes/block offsets with two files', function (t) {
     var correctBlocks = archive.content.blocks
     archive.append('misc.js', function (err) {
       t.error(err, 'no error')
-      archive.list(function (err, entries) {
+      archive.history(function (err, entries) {
         t.error(err, 'no error')
         t.same(entries.length, 2, 'two entries')
         t.same(entries[1].content.bytesOffset, correctBytes, 'correct offset')

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -276,7 +276,7 @@ tape('replicates unlinks', function (t) {
   var clone = driveClone.createArchive(archive.key, {
     file: function (name) {
       return raf(path.join(tmpdir2.name, name))
-    }    
+    }
   })
 
   var stream = archive.replicate()
@@ -288,7 +288,6 @@ tape('replicates unlinks', function (t) {
   var ws = archive.createFileWriteStream('hello.txt')
   ws.end('BEEP BOOP\n')
   ws.on('finish', function () {
-
     // replicate and ensure content
     clone.download(0, function (err) {
       t.error(err, 'no error')
@@ -301,7 +300,7 @@ tape('replicates unlinks', function (t) {
           t.error(err, 'no error')
 
           ensureDeleted(path.join(tmpdir1.name, 'hello.txt'), 'original')
-          
+
           // replicate and ensure deletion
           clone.download(1, function (err) {
             t.error(err, 'no error')
@@ -309,7 +308,6 @@ tape('replicates unlinks', function (t) {
             ensureDeleted(path.join(tmpdir2.name, 'hello.txt'), 'clone')
             t.end()
           })
-
         })
       }))
     })
@@ -324,6 +322,6 @@ tape('replicates unlinks', function (t) {
       notFound = stat.blocks === 0
     } catch (e) {}
     if (notFound) t.pass(path.basename(filepath) + ' was deleted in ' + archiveName)
-    else          t.fail(path.basename(filepath) + ' should have been deleted in ' + archiveName)
+    else t.fail(path.basename(filepath) + ' should have been deleted in ' + archiveName)
   }
 })


### PR DESCRIPTION
This PR closes #76. The changes are described in the readme:

---
#### `var rs = archive.history(opts={}, cb)`

Returns a readable stream of the history of the entries in the archive.
- `opts.offset` - start streaming from this offset (default: 0)
- `opts.live` - keep the stream open as new updates arrive (default: false)

You can collect the results of the stream with `cb(err, entries)`.
#### `var rs = archive.list(opts={}, cb)`

Returns a readable stream of all current entries in the archive.
- `opts.offset` - start streaming from this offset (default: 0)

You can collect the results of the stream with `cb(err, entries)`.
#### `archive.unlink(entry, callback)`

Remove an entry from the archive. Only possible if this is an live archive you originally created
or an unfinalized archive.

This will not affect the files on the disk, even if you set the file option in the archive constructor.
