### PR TITLE
Versioning API (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,7 @@ Boolean whether archive is live. `true` by default. Note that its only populated
 
 #### `archive.version`
 
-The label of the most recent checkpoint.
-
-#### `archive.semver`
-
-The label of the most recent semantic-version checkpoint.
-This can differ from `archive.version` when the most recent checkpoint was not a semver. 
+The label of the most recent checkpoint. Note that its only populated after archive.open(cb) has been fired.
 
 #### `archive.append(entry, callback)`
 
@@ -156,23 +151,23 @@ archive.append('hello.txt', function () {
 })
 ```
 
-#### `archive.checkpoint(version, [callback])`
+#### `archive.checkpoint(desc, [callback])`
 
-Write a version checkpoint to the archive, marking the state for future reference. Version includes:
+Write a version checkpoint to the archive, marking the state for future reference. Desc includes:
 
 ```js
 {
-  label: '1.0.0', // can be any string, but semantic versions are recommended
+  version: '1.0.0', // can be any string, but semantic versions are recommended
   message: 'The first version!' // an optional string describing the checkpoint
 }
 ```
 
-If the label has been used before, Hyperdrive will error.
-If the label is a semantic version, Hyperdrive will error if it isn't a greater version than all previous semver checkpoints.
+If the version has been used before, Hyperdrive will error.
+If the version is a [Semantic Version](http://semver.org/), Hyperdrive will error if it isn't a greater version than all previous semver checkpoints.
 
 You can mix semvers with non-semver labels.
 
-Hyperdrive automatically adds a `.timestamp` value to `version`, using `Date.now()`.
+Hyperdrive automatically adds a `.timestamp` value to `desc`, using `Date.now()`.
 You can override this by setting your own `.timestamp` if needed.
 
 #### `archive.finalize([callback])`

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Write a checkpoint to the archive, marking the state for future reference. Desc 
 ```js
 {
   name: '1.0.0', // can be any string
-  message: 'The first version!' // an optional string describing the checkpoint
+  description: 'The first version!' // an optional string describing the checkpoint
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Otherwise it is a 32 byte hash.
 
 Boolean whether archive is live. `true` by default. Note that its only populated after archive.open(cb) has been fired.
 
+#### `archive.version`
+
+The label of the most recent checkpoint.
+
+#### `archive.semver`
+
+The label of the most recent semantic-version checkpoint.
+This can differ from `archive.version` when the most recent checkpoint was not a semver. 
+
 #### `archive.append(entry, callback)`
 
 Append an entry to the archive. Only possible if this is an live archive you originally created
@@ -146,6 +155,25 @@ archive.append('hello.txt', function () {
   console.log('hello.txt was read and appended')
 })
 ```
+
+#### `archive.checkpoint(version, [callback])`
+
+Write a version checkpoint to the archive, marking the state for future reference. Version includes:
+
+```js
+{
+  label: '1.0.0', // can be any string, but semantic versions are recommended
+  message: 'The first version!' // an optional string describing the checkpoint
+}
+```
+
+If the label has been used before, Hyperdrive will error.
+If the label is a semantic version, Hyperdrive will error if it isn't a greater version than all previous semver checkpoints.
+
+You can mix semvers with non-semver labels.
+
+Hyperdrive automatically adds a `.timestamp` value to `version`, using `Date.now()`.
+You can override this by setting your own `.timestamp` if needed.
 
 #### `archive.finalize([callback])`
 
@@ -188,6 +216,15 @@ Returns a readable stream of all entries in the archive.
 * `opts.live` - keep the stream open as new updates arrive (default: `true` if no callback given, `false` if callback is given)
 
 You can collect the results of the stream with `cb(err, entries)`.
+
+#### `var rs = archive.versions(opts={}, cb)`
+
+Returns a readable stream of all version checkpoints in the archive.
+
+* `opts.offset` - start streaming from this offset (default: 0)
+* `opts.live` - keep the stream open as new updates arrive (default: false)
+
+You can collect the results of the stream with `cb(err, versions)`.
 
 #### `var rs = archive.createFileReadStream(entry, [options])`
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ Otherwise it is a 32 byte hash.
 
 Boolean whether archive is live. `true` by default. Note that its only populated after archive.open(cb) has been fired.
 
-#### `archive.version`
-
-The label of the most recent checkpoint. Note that its only populated after archive.open(cb) has been fired.
-
 #### `archive.append(entry, callback)`
 
 Append an entry to the archive. Only possible if this is an live archive you originally created
@@ -153,19 +149,16 @@ archive.append('hello.txt', function () {
 
 #### `archive.checkpoint(desc, [callback])`
 
-Write a version checkpoint to the archive, marking the state for future reference. Desc includes:
+Write a checkpoint to the archive, marking the state for future reference. Desc includes:
 
 ```js
 {
-  version: '1.0.0', // can be any string, but semantic versions are recommended
+  name: '1.0.0', // can be any string
   message: 'The first version!' // an optional string describing the checkpoint
 }
 ```
 
-If the version has been used before, Hyperdrive will error.
-If the version is a [Semantic Version](http://semver.org/), Hyperdrive will error if it isn't a greater version than all previous semver checkpoints.
-
-You can mix semvers with non-semver labels.
+If the name has been used before, Hyperdrive will error.
 
 Hyperdrive automatically adds a `.timestamp` value to `desc`, using `Date.now()`.
 You can override this by setting your own `.timestamp` if needed.
@@ -212,14 +205,14 @@ Returns a readable stream of all entries in the archive.
 
 You can collect the results of the stream with `cb(err, entries)`.
 
-#### `var rs = archive.versions(opts={}, cb)`
+#### `var rs = archive.checkpoints(opts={}, cb)`
 
-Returns a readable stream of all version checkpoints in the archive.
+Returns a readable stream of all checkpoints in the archive.
 
 * `opts.offset` - start streaming from this offset (default: 0)
 * `opts.live` - keep the stream open as new updates arrive (default: false)
 
-You can collect the results of the stream with `cb(err, versions)`.
+You can collect the results of the stream with `cb(err, checkpoints)`.
 
 #### `var rs = archive.createFileReadStream(entry, [options])`
 

--- a/archive.js
+++ b/archive.js
@@ -7,6 +7,7 @@ var rabin = process.browser ? require('through2') : require('rabin')
 var pump = require('pump')
 var pumpify = require('pumpify')
 var collect = require('stream-collector')
+var through = require('through2')
 var storage = require('./storage')
 var cursor = require('./cursor')
 var encoding = require('hyperdrive-encoding')
@@ -33,6 +34,7 @@ function Archive (drive, key, opts) {
   this._appending = []
   this._indexBlock = -1
   this._finalized = false
+  this._isCheckpointingLocked = false
 
   function open (cb) {
     self._open(cb)
@@ -118,6 +120,23 @@ Archive.prototype.list = function (opts, cb) {
       range = self.metadata.prioritize({prioritize: 3, start: offset, end: offset + limit, linear: true})
       read(size, cb)
     })
+  }
+}
+
+Archive.prototype.checkpoints = function (opts, cb) {
+  if (typeof opts === 'function') return this.checkpoints(null, opts)
+  if (!opts) opts = {}
+
+  var offset = opts.offset || 0
+  var live = opts.live === false ? false : (opts.live || !cb)
+
+  return collect(pumpify.obj(this.list({ offset: offset, live: live }), through.obj(filter)), cb)
+
+  function filter (entry, enc, callback) {
+    if (entry && entry.type === 'checkpoint') {
+      this.push(entry)
+    }
+    callback()
   }
 }
 
@@ -207,6 +226,60 @@ Archive.prototype.countDownloadedBlocks = function (entry) {
 
 Archive.prototype.isEntryDownloaded = function (entry) {
   return this.countDownloadedBlocks(entry) === entry.blocks
+}
+
+Archive.prototype.checkpoint = function (entry, cb) {
+  if (!cb) cb = noop
+  assertFinalized(this)
+
+  var name = isString(entry.name) ? entry.name : undefined
+  var description = isString(entry.description) ? entry.description : undefined
+  var timestamp = typeof entry.timestamp === 'number' ? entry.timestamp : Date.now()
+  var self = this
+
+  if (!name) {
+    throw new Error('Checkpoint requires a .name')
+  }
+
+  this.open(function (err) {
+    if (err) return cb(err)
+
+    // aqcuire the checkpoint lock
+    if (self._isCheckpointingLocked) {
+      return cb(new Error('A checkpoint is currently being written'))
+    }
+    self._isCheckpointingLocked = true
+
+    // read current checkpoints
+    self.checkpoints(function (err, checkpoints) {
+      if (err) {
+        self._isCheckpointingLocked = false
+        return cb(err)
+      }
+
+      // ensure the name has not been used yet
+      for (var i = 0; i < checkpoints.length; i++) {
+        if (checkpoints[i].name === name) {
+          return cb(new Error('A checkpoint with this name has already been written'))
+        }
+      }
+
+      // write the checkpoint entry
+      var message = {
+        type: 'checkpoint',
+        name: name,
+        timestamp: timestamp
+      }
+      if (description) {
+        message.description = description
+      }
+      self._writeEntry(message, function (err) {
+        self._isCheckpointingLocked = false
+        if (err) return cb(err)
+        cb()
+      })
+    })
+  })
 }
 
 Archive.prototype.finalize = function (cb) {
@@ -622,4 +695,8 @@ function assertFinalized (self) {
 
 function isStream (stream) {
   return stream && typeof stream.pipe === 'function'
+}
+
+function isString (str) {
+  return str && typeof str === 'string'
 }

--- a/test/checkpoints.js
+++ b/test/checkpoints.js
@@ -1,0 +1,66 @@
+var tape = require('tape')
+var memdb = require('memdb')
+var hyperdrive = require('../')
+
+tape('checkpoints', function (t) {
+  var drive = hyperdrive(memdb())
+
+  var archive = drive.createArchive({ live: true })
+
+  // write 1.0.0
+  var ws = archive.createFileWriteStream('hello.txt')
+  ws.end('BEEP BOOP\n')
+  ws.once('finish', function () {
+    archive.checkpoint({ name: '1.0.0', description: 'The first commit' }, function (err) {
+      t.error(err, 'no error')
+
+      // write 2.0.0
+      var ws = archive.createFileWriteStream('hello.txt')
+      ws.end('BOOP BEEP\n')
+      ws.once('finish', function () {
+        archive.checkpoint({ name: '2.0.0', description: 'The second commit' }, function (err) {
+          t.error(err, 'no error')
+
+          archive.checkpoints(function (err, checkpoints) {
+            t.error(err, 'no error')
+
+            t.same(checkpoints.length, 2)
+            t.same(checkpoints[0].name, '1.0.0')
+            t.same(checkpoints[1].name, '2.0.0')
+            t.same(checkpoints[0].description, 'The first commit')
+            t.same(checkpoints[1].description, 'The second commit')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('checkpoint locking', function (t) {
+  t.plan(2)
+
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive({ live: true })
+
+  archive.checkpoint({ name: '1.0.0' }, function (err) {
+    t.error(err, 'no error')
+  })
+  archive.checkpoint({ name: '1.0.1' }, function (err) {
+    t.ok(err, 'lock was not available')
+  })
+})
+
+tape('checkpoint name is not reusable', function (t) {
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive({ live: true })
+
+  archive.checkpoint({ name: '1.0.0' }, function (err) {
+    t.error(err, 'no error')
+
+    archive.checkpoint({ name: '1.0.0' }, function (err) {
+      t.ok(err, err.message)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
This PR is a work-in-progress. It will add version checkpoints, which Hyperdrive's API can create and list, and use to find specific versions of files in its history.

I've written a new message-type in the schema, and updated the readme with the API that I propose for this. I need the changes to `list()` to be merged (https://github.com/mafintosh/hyperdrive/pull/99) before I can finish updating the API (`list` will take a 'version' option).

Let me know if you think anything should change!
