### PR TITLE
Fix doc about default value of live of archive.list()

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Returns a readable stream of all entries in the archive.
 
 * `opts.offset` - start streaming from this offset (default: 0)
 * `opts.limit` - stop streaming at this offset (default: no limit)
-* `opts.live` - keep the stream open as new updates arrive (default: false)
+* `opts.live` - keep the stream open as new updates arrive (default: `true` if no callback given, `false` if callback is given)
 
 You can collect the results of the stream with `cb(err, entries)`.
 


### PR DESCRIPTION
```
  var live = opts.live === false ? false : (opts.live || !cb)
```

archive.list() have different default for `live` option based on callback is given or not
- `archive.list(cb)` : `live` is false
- `var rs = archive.list()` : `live` is true
