### PR TITLE
allow feeds to be passed to createArchive directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ as the first argument. Options include
 
 If you do not provide the file option all file data is stored in the leveldb.
 
+If the `metadata` and `content` hypercore feeds were already created, they can be passed in directly as options:
+
+```js
+var archive = drive.createArchive(key, {
+  metadata: core.createFeed(key),
+  content: core.createFeed(contentKey)
+})
+```
+
 #### `archive.key`
 
 A buffer that verifies the archive content. In live mode this is a 32 byte public key.

--- a/archive.js
+++ b/archive.js
@@ -20,8 +20,8 @@ function Archive (drive, key, opts) {
   this.options = opts || {}
   this.drive = drive
   this.live = this.options.live = !key && (this.options.live !== false)
-  this.metadata = drive.core.createFeed(key, this.options)
-  this.content = null
+  this.metadata = this.options.metadata || drive.core.createFeed(key, this.options)
+  this.content = this.options.content || null
   this.key = key || this.metadata.key
   this.discoveryKey = this.metadata.discoveryKey
   this.owner = !key
@@ -528,7 +528,7 @@ Archive.prototype._open = function (cb) {
     if (self._closed) return cb(new Error('Archive is closed'))
     if (self.options.file) self.options.storage = storage(self)
     self.options.key = index && index.content
-    self.content = self.drive.core.createFeed(null, self.options)
+    if (!self.content) self.content = self.drive.core.createFeed(null, self.options)
     self.live = self.metadata.live
 
     self.content.on('download', function (block, data) {


### PR DESCRIPTION
Hypercore feeds can be passed to `createArchive` as `metadata` and `content` options.

The test is pretty basic. Let me know if there is other things that would be good to test here.