### PR TITLE
pass metadata block seq to .file

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -389,7 +389,7 @@ Archive.prototype.append = function (entry, cb) {
     if (entry.type === 'file') {
       if (!self.options.storage) throw new Error('Set options.file to append files')
 
-      var rs = fileReadStream(self.options.file(entry.name, self.options))
+      var rs = fileReadStream(self.options.file(entry.name, self.options, self.metadata.blocks))
       var ws = self.createFileWriteStream(entry, {indexing: true})
       pump(rs, ws, cb)
     } else {

--- a/storage.js
+++ b/storage.js
@@ -74,7 +74,7 @@ Storage.prototype._open = function (offset, length, buf, cb) {
   var result = {
     start: offset,
     end: Infinity,
-    storage: this.archive.options.file(this._appendingName, this.archive.options)
+    storage: this.archive.options.file(this._appendingName, this.archive.options, this.archive.metadata.blocks)
   }
   this._appendingName = null
   this._appending = result
@@ -121,7 +121,7 @@ function bisect (self, offset, length, buffer, cb) {
       var result = {
         start: start,
         end: end,
-        storage: self.archive.options.file(data.name, self.archive.options)
+        storage: self.archive.options.file(data.name, self.archive.options, mid)
       }
 
       fns.add(self._opened, result, cmp)


### PR DESCRIPTION
adds `file(name, archiveOptions, seq)`