### PR TITLE
add replicate test with file updates

### DIFF
--- a/test/replicates.js
+++ b/test/replicates.js
@@ -345,16 +345,77 @@ tape('replicates file after update with raf opts', function (t) {
   })
 
   function doClone () {
-    var clone = driveClone.createArchive(archive.key)
+    var clone = driveClone.createArchive(archive.key, {
+      verifyReplicationReads: true
+    })
     var buf = []
 
     clone.open(function () {
+      t.pass('open')
       clone.content.on('download-finished', function () {
         clone.createFileReadStream(0)
         .on('data', function (data) {
           buf.push(data)
         })
         .on('end', function () {
+          t.same(Buffer.concat(buf), fs.readFileSync(testFile))
+          fs.unlink(testFile, function () {
+            t.end()
+          })
+        })
+      })
+    })
+
+    var stream = archive.replicate()
+    var streamClone = clone.replicate()
+
+    stream.pipe(streamClone).pipe(stream)
+  }
+})
+
+tape('replicates file after update via download with raf opts', function (t) {
+  var drive = hyperdrive(memdb())
+  var driveClone = hyperdrive(memdb())
+
+  var archive = drive.createArchive({
+    file: function (name, opts) {
+      return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+    }
+  })
+
+  var testFile = path.join(__dirname, 'test.txt')
+
+  fs.writeFile(testFile, 'hello', function (err) {
+    t.error(err, 'no err')
+
+    archive.append('test.txt', function (err) {
+      t.error(err, 'no error')
+
+      fs.appendFile(testFile, '\nworld', function (err) {
+        t.error(err, 'no err')
+
+        archive.append('test.txt', function (err) {
+          t.error(err, 'no error')
+          doClone()
+        })
+      })
+    })
+  })
+
+  function doClone () {
+    var clone = driveClone.createArchive(archive.key, {
+      verifyReplicationReads: true
+    })
+    var buf = []
+
+    clone.open(function () {
+      clone.download(0, function () {
+        clone.createFileReadStream(0)
+        .on('data', function (data) {
+          buf.push(data)
+        })
+        .on('end', function () {
+          console.log([Buffer.concat(buf).toString(), fs.readFileSync(testFile, 'utf8')])
           t.same(Buffer.concat(buf), fs.readFileSync(testFile))
           fs.unlink(testFile, function () {
             t.end()

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -259,3 +259,113 @@ tape('downloads empty directories to fs', function (t) {
     stream.pipe(streamClone).pipe(stream)
   })
 })
+
+tape('replicates file after update without raf opts', function (t) {
+  var drive = hyperdrive(memdb())
+  var driveClone = hyperdrive(memdb())
+
+  var archive = drive.createArchive({
+    file: function (name) {
+      return raf(path.join(__dirname, name))
+    }
+  })
+
+  var testFile = path.join(__dirname, 'test.txt')
+
+  fs.writeFile(testFile, 'hello', function (err) {
+    t.error(err, 'no err')
+
+    archive.append('test.txt', function (err) {
+      t.error(err, 'no error')
+
+      fs.appendFile(testFile, '\nworld', function (err) {
+        t.error(err, 'no err')
+
+        archive.append('test.txt', function (err) {
+          t.error(err, 'no error')
+          doClone()
+        })
+      })
+    })
+  })
+
+  function doClone () {
+    var clone = driveClone.createArchive(archive.key)
+    var buf = []
+
+    clone.open(function () {
+      clone.content.on('download-finished', function () {
+        clone.createFileReadStream(0)
+        .on('data', function (data) {
+          buf.push(data)
+        })
+        .on('end', function () {
+          t.same(Buffer.concat(buf), fs.readFileSync(testFile))
+          fs.unlink(testFile, function () {
+            t.end()
+          })
+        })
+      })
+    })
+
+    var stream = archive.replicate()
+    var streamClone = clone.replicate()
+
+    stream.pipe(streamClone).pipe(stream)
+  }
+})
+
+tape('replicates file after update with raf opts', function (t) {
+  var drive = hyperdrive(memdb())
+  var driveClone = hyperdrive(memdb())
+
+  var archive = drive.createArchive({
+    file: function (name, opts) {
+      return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+    }
+  })
+
+  var testFile = path.join(__dirname, 'test.txt')
+
+  fs.writeFile(testFile, 'hello', function (err) {
+    t.error(err, 'no err')
+
+    archive.append('test.txt', function (err) {
+      t.error(err, 'no error')
+
+      fs.appendFile(testFile, '\nworld', function (err) {
+        t.error(err, 'no err')
+
+        archive.append('test.txt', function (err) {
+          t.error(err, 'no error')
+          doClone()
+        })
+      })
+    })
+  })
+
+  function doClone () {
+    var clone = driveClone.createArchive(archive.key)
+    var buf = []
+
+    clone.open(function () {
+      clone.content.on('download-finished', function () {
+        clone.createFileReadStream(0)
+        .on('data', function (data) {
+          buf.push(data)
+        })
+        .on('end', function () {
+          t.same(Buffer.concat(buf), fs.readFileSync(testFile))
+          fs.unlink(testFile, function () {
+            t.end()
+          })
+        })
+      })
+    })
+
+    var stream = archive.replicate()
+    var streamClone = clone.replicate()
+
+    stream.pipe(streamClone).pipe(stream)
+  }
+})


### PR DESCRIPTION
Adds two tests, one of them is failing (the one that uses `raf` options for the length stuff).