### PR TITLE
add replicate test that errors

### DIFF
--- a/test/replicates.js
+++ b/test/replicates.js
@@ -4,6 +4,7 @@ var path = require('path')
 var fs = require('fs')
 var tmp = require('tmp')
 var raf = require('random-access-file')
+var rimraf = require('rimraf')
 var hyperdrive = require('../')
 
 tape('replicates file', function (t) {
@@ -345,9 +346,11 @@ tape('replicates file after update with raf opts', function (t) {
   })
 
   function doClone () {
+    var cloneDir = path.join(__dirname, 'tmp')
+    rimraf.sync(cloneDir)
     var clone = driveClone.createArchive(archive.key, {
       file: function (name, opts) {
-        return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+        return raf(path.join(cloneDir, name), opts && typeof opts.length === 'number' && {length: opts.length})
       }
     })
     var buf = []
@@ -362,6 +365,7 @@ tape('replicates file after update with raf opts', function (t) {
         .on('end', function () {
           t.same(Buffer.concat(buf), fs.readFileSync(testFile))
           fs.unlink(testFile, function () {
+            rimraf.sync(cloneDir)
             t.end()
           })
         })
@@ -405,11 +409,13 @@ tape('replicates file after update via download with raf opts', function (t) {
   })
 
   function doClone () {
+    var cloneDir = path.join(__dirname, 'tmp')
+    rimraf.sync(cloneDir)
     var clone = driveClone.createArchive(archive.key, {
       verifyReplicationReads: true,
       sparse: true,
       file: function (name, opts) {
-        return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+        return raf(path.join(cloneDir, name), opts && typeof opts.length === 'number' && {length: opts.length})
       }
     })
     var buf = []
@@ -424,6 +430,7 @@ tape('replicates file after update via download with raf opts', function (t) {
           console.log([Buffer.concat(buf).toString(), fs.readFileSync(testFile, 'utf8')])
           t.same(Buffer.concat(buf), fs.readFileSync(testFile))
           fs.unlink(testFile, function () {
+            rimraf.sync(cloneDir)
             t.end()
           })
         })
@@ -467,11 +474,11 @@ tape('replicates file with sparse mode and raf opts', function (t) {
   })
 
   function doClone () {
+    var cloneDir = path.join(__dirname, 'tmp')
+    rimraf.sync(cloneDir)
     var clone = driveClone.createArchive(archive.key, {
-      sparse: false,
-      verifyReplicationReads: false,
       file: function (name, opts) {
-        return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+        return raf(path.join(cloneDir, name), opts && typeof opts.length === 'number' && {length: opts.length})
       }
     })
     var buf = []
@@ -489,6 +496,7 @@ tape('replicates file with sparse mode and raf opts', function (t) {
             fs.unlink(testFile, function () {
               clone.list(function (_, entries) {
                 console.log(entries)
+                rimraf.sync(cloneDir)
                 t.end()
               })
             })

--- a/test/replicates.js
+++ b/test/replicates.js
@@ -295,7 +295,7 @@ tape('replicates file after update without raf opts', function (t) {
 
     clone.open(function () {
       clone.content.on('download-finished', function () {
-        clone.createFileReadStream(0)
+        clone.createFileReadStream(1)
         .on('data', function (data) {
           buf.push(data)
         })
@@ -346,7 +346,9 @@ tape('replicates file after update with raf opts', function (t) {
 
   function doClone () {
     var clone = driveClone.createArchive(archive.key, {
-      verifyReplicationReads: true
+      file: function (name, opts) {
+        return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+      }
     })
     var buf = []
 
@@ -404,13 +406,17 @@ tape('replicates file after update via download with raf opts', function (t) {
 
   function doClone () {
     var clone = driveClone.createArchive(archive.key, {
-      verifyReplicationReads: true
+      verifyReplicationReads: true,
+      sparse: true,
+      file: function (name, opts) {
+        return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
+      }
     })
     var buf = []
 
     clone.open(function () {
-      clone.download(0, function () {
-        clone.createFileReadStream(0)
+      clone.download(1, function () {
+        clone.createFileReadStream(1)
         .on('data', function (data) {
           buf.push(data)
         })
@@ -462,8 +468,8 @@ tape('replicates file with sparse mode and raf opts', function (t) {
 
   function doClone () {
     var clone = driveClone.createArchive(archive.key, {
-      sparse: true,
-      verifyReplicationReads: true,
+      sparse: false,
+      verifyReplicationReads: false,
       file: function (name, opts) {
         return raf(path.join(__dirname, name), opts && typeof opts.length === 'number' && {length: opts.length})
       }


### PR DESCRIPTION
This is a failing test that I think is caused by the bug below.

The bug seems to be if `opts.lenght` is set for `random-access-file` then it will truncating the files when it gets the latest file first and then older files later. Here is what is happening:

* Hyperdrive is getting the latest file from block 4 - `hello.txt` with 4 lines - using `_selectLatest`
* raf is properly writing the file and truncating it to 4 lines
* hypercore/replicate says `no more messages wanted`
* But then hypercore/replicate `write()` is called.
* raf writes the file from block 0 - `hello.txt` with 1 lines, truncating it.
* This keeps happening until the file gets to one block short of latest, where it should be. So if the `n-1` update for `hello.txt` was shorter than the `nth` it'll get truncated improperly.

Not quite sure what is happening. But it seems like `sparse: true` isn't actually working for the file if we request it from  `_selectLatest`.

In the example below, the file was done downloading (`hello.txt` with `hello, two, three, 4`) but then *something in hypercore/replicate* makes it keep downloading the rest of the blocks - each time truncating the file to a shorter size than the first download, which was latest. 

```
  hyperdrive-storage write() 32 32 hello
two
three
4
 +0ms
  random-access-file opened file=/Users/joe/tmp/down/hello.txt +1ms
  random-access-file should truncate? 18 undefined +0ms
  random-access-file write() hello
two
three
4
 18 0 +1ms
 hyperdrive-archive download() isEntryDownloaded true +0ms
  hypercore-replicate chan=acd232..7d update() stopping, no more messages wanted +0ms
  hypercore-replicate chan=acd232..7d write() block=0 +0ms
  hyperdrive-storage write open hello
 +0ms
  hyperdrive-storage _open() 0 0 hello
 +0ms
  hyperdrive-storage bisect() 0 0 hello
 6 +0ms
  random-access-file open() file=/Users/joe/tmp/down/hello.txt +2ms
  random-access-file creating containing directory /Users/joe/tmp/down +0ms
  hyperdrive-storage bisect() done write hello
 +1ms
  hyperdrive-storage write() 0 0 hello
 +0ms
  random-access-file opened file=/Users/joe/tmp/down/hello.txt +0ms
  random-access-file should truncate? 6 undefined +0ms
```