### PR TITLE
only set latest for downloaders

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -30,7 +30,7 @@ function Archive (drive, key, opts) {
   this.open = thunky(open)
   this.id = drive.id
 
-  this._onlyLatest = !!opts.file
+  this._onlyLatest = !!opts.file && !this.owner
   this._sparse = !!this.options.sparse
   this._closed = false
   this._appending = []

--- a/archive.js
+++ b/archive.js
@@ -569,7 +569,10 @@ Archive.prototype._open = function (cb) {
     if (err) return cb(err)
     if (self._closed) return cb(new Error('Archive is closed'))
 
-    if (!self.owner && self.metadata.secretKey) self.owner = true // TODO: hypercore should tell you this
+    if (!self.owner && self.metadata.secretKey) {
+      self.owner = true // TODO: hypercore should tell you this
+      self._onlyLatest = false
+    }
 
     if (!self.owner || self.metadata.blocks) waitForIndex(null)
     else onindex(null)


### PR DESCRIPTION
`_onlyLatest` should always be false for archive owners. 

I think this was another cause of some of our source corruption. If not, it'll at least avoid a bunch of download requests overhead.

Sometimes owners will still use `opts.file` (for example if you want to do `archive.append`, its required).