### PR TITLE
stop selectLatest if archive is closed

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -73,6 +73,7 @@ Archive.prototype._selectLatest = function () {
     loop()
 
     function loop () {
+      if (self._closed) return
       self.get(--blk, function (err, entry) {
         if (err) return
         if (!entry.content || entry.type !== 'file') return loop()
@@ -91,6 +92,7 @@ Archive.prototype._selectLatest = function () {
     for (var i = 0; i < 64; i++) loop()
 
     function loop () {
+      if (self._closed) return cb()
       if (downloading > 64 || !names.length) return
       var next = names.shift()
       downloading++


### PR DESCRIPTION
`_selectLatest` keeps trying to download stuff even after the archive is closed. This is causing lots of seg faults when we try to close things. 

PR makes sure we stop loops if archive is closed.