### PR TITLE
Fix sparse archive option with file option

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -606,7 +606,7 @@ Archive.prototype._open = function (cb) {
     if (self._closed) return cb(new Error('Archive is closed'))
     if (self.options.file) self.options.storage = storage(self)
     self.options.key = index && index.content
-    if (!self.metadata.live) self._onlyLatest = false
+    if (!self.metadata.live || self.options.sparse) self._onlyLatest = false
     var contentOpts = self._onlyLatest ? {sparse: true} : {}
     if (self.options.contentStorage) self.options.storage = self.options.contentStorage
     if (!self.content) self.content = self.drive.core.createFeed(null, xtend(self.options, contentOpts))


### PR DESCRIPTION
Right now `sparse` doesn't work if the `file` option is also set because `_selectLatest` gets called. PR adds a test and fix.

* Adds a test using both `opts.sparse: true` and `opts.file`
* Set `_onlyLatest` to false if sparse is true