### PR TITLE
Normalize paths on lookup()

### DIFF
--- a/archive.js
+++ b/archive.js
@@ -238,9 +238,10 @@ Archive.prototype.get = function (index, opts, cb) {
 Archive.prototype.lookup = function (name, cb) {
   var entries = this.list({live: false})
   var result = null
+  name = normalizeEntryPath(name)
 
   entries.on('data', function (data) {
-    if (data.name !== name) return
+    if (normalizeEntryPath(data.name) !== name) return
     result = data
   })
 
@@ -696,4 +697,12 @@ function assertFinalized (self) {
 
 function isStream (stream) {
   return stream && typeof stream.pipe === 'function'
+}
+
+function normalizeEntryPath (path) {
+  // strip leading slashes
+  if (typeof path === 'string' && path.charAt(0) === '/') {
+    return path.slice(1)
+  }
+  return path
 }

--- a/test/misc.js
+++ b/test/misc.js
@@ -280,3 +280,19 @@ tape('create archive with feeds', function (t) {
     stream.pipe(streamClone).pipe(stream)
   })
 })
+
+tape('normalized reads', function (t) {
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive()
+
+  archive.createFileWriteStream('hello.txt').end('hello world')
+  archive.finalize(function () {
+    archive.get('hello.txt', function (err, entry) {
+      t.error(err, 'no error')
+      archive.get('/hello.txt', function (err, entry) {
+        t.error(err, 'no error')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
The hyperdrive ecosystem doesnt enforce whether there should be a preceding slash on file entries in the metadata stream. This means that lookups can sometimes fail because of different policies on preceding slashes. This PR fixes that in lookup().

(Solves a problem in bkr)