### PR TITLE
add storage tests for secret key bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "random-access-memory": "^2.3.0",
     "standard": "^9.0.2",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "temporary-directory": "^1.0.2"
   },
   "scripts": {
     "test": "standard && tape test/*.js"

--- a/test/storage.js
+++ b/test/storage.js
@@ -1,0 +1,59 @@
+var tape = require('tape')
+var tmp = require('temporary-directory')
+var create = require('./helpers/create')
+var hyperdrive = require('..')
+
+tape('ram storage', function (t) {
+  var archive = create()
+
+  archive.ready(function () {
+    t.ok(archive.metadata.writable, 'archive metadata is writable')
+    t.ok(archive.content.writable, 'archive content is writable')
+    t.end()
+  })
+})
+
+tape('dir storage with resume', function (t) {
+  tmp(function (err, dir, cleanup) {
+    t.ifError(err)
+    var archive = hyperdrive(dir)
+    archive.ready(function () {
+      t.ok(archive.metadata.writable, 'archive metadata is writable')
+      t.ok(archive.content.writable, 'archive content is writable')
+
+      var archive2 = hyperdrive(dir)
+      archive2.ready(function () {
+        t.ok(archive2.metadata.writable, 'archive2 metadata is writable')
+        t.ok(archive2.content.writable, 'archive2 content is writable')
+
+        cleanup(function (err) {
+          t.ifError(err)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+tape('dir storage for non-writable archive', function (t) {
+  var src = create()
+  src.ready(function () {
+    tmp(function (err, dir, cleanup) {
+      t.ifError(err)
+
+      var clone = hyperdrive(dir, src.key)
+      clone.on('content', function () {
+        t.ok(!clone.metadata.writable, 'clone metadata not writable')
+        t.ok(!clone.content.writable, 'clone content not writable')
+        t.same(clone.key, src.key, 'keys match')
+        cleanup(function (err) {
+          t.ifError(err)
+          t.end()
+        })
+      })
+
+      var stream = clone.replicate()
+      stream.pipe(src.replicate()).pipe(stream)
+    })
+  })
+})


### PR DESCRIPTION
* Add a [failing test](https://github.com/mafintosh/hyperdrive/compare/master...joehand:secret-key-test?expand=1#diff-6a1112979275ee9654c3b1f5a4c15c2dR16) for secret key bug
* Also adds a few basic storage tests

Not sure how best to *resume* an existing archive with v8 API, but this seems to work =). Passing secret key in https://github.com/mafintosh/hyperdrive/blob/master/index.js#L393-L395 fixes bug + passes test.