### PR TITLE
Readme: Add origKey to replicate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ server.listen(10000)
 
 // ... on another
 
-var clonedArchive = hyperdrive('./my-cloned-hyperdrive')
+var clonedArchive = hyperdrive('./my-cloned-hyperdrive', origKey)
 var socket = net.connect(10000)
 
 socket.pipe(clonedArchive.replicate()).pipe(socket)


### PR DESCRIPTION
Based on some errors I just got, it looks like including the original archive's key is required for replication