### PR TITLE
Fix archive.version for resumed archives

### DIFF
--- a/index.js
+++ b/index.js
@@ -424,8 +424,7 @@ Hyperdrive.prototype._open = function (cb) {
     if (err) return cb(err)
     self.metadata.ready(function (err) {
       if (err) return cb(err)
-
-      self.version = tree.version
+      self.version = self.tree.version
       if (self.content) return cb(null)
 
       self.key = self.metadata.key
@@ -444,7 +443,10 @@ Hyperdrive.prototype._open = function (cb) {
 
   function onwritable () {
     var wroteIndex = self.metadata.has(0)
-    if (wroteIndex) return self._loadIndex(cb)
+    if (wroteIndex) {
+      if (self.version === -1) self.version = 0 // TODO: perhaps fix in append-tree?
+      return self._loadIndex(cb)
+    }
 
     if (!self.content) {
       var keyPair = contentKeyPair(self.metadata.secretKey)

--- a/test/storage.js
+++ b/test/storage.js
@@ -20,15 +20,20 @@ tape('dir storage with resume', function (t) {
     archive.ready(function () {
       t.ok(archive.metadata.writable, 'archive metadata is writable')
       t.ok(archive.content.writable, 'archive content is writable')
+      t.same(archive.version, 0, 'archive has version 0')
+      archive.close(function (err) {
+        t.ifError(err)
 
-      var archive2 = hyperdrive(dir)
-      archive2.ready(function () {
-        t.ok(archive2.metadata.writable, 'archive2 metadata is writable')
-        t.ok(archive2.content.writable, 'archive2 content is writable')
+        var archive2 = hyperdrive(dir)
+        archive2.ready(function () {
+          t.ok(archive2.metadata.writable, 'archive2 metadata is writable')
+          t.ok(archive2.content.writable, 'archive2 content is writable')
+          t.same(archive2.version, 0, 'archive has version 0')
 
-        cleanup(function (err) {
-          t.ifError(err)
-          t.end()
+          cleanup(function (err) {
+            t.ifError(err)
+            t.end()
+          })
         })
       })
     })


### PR DESCRIPTION
* Fix bug missing self in `self.tree` variable to set version for existing feeds
* Add `version = -1` fix for existing archives
* Add version tests to storage test