### PR TITLE
add indexing to content feed

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function Hyperdrive (storage, key, opts) {
   if (typeof opts.version === 'number') this.tree = this.tree.checkout(opts.version)
   this.version = this.tree.version
   this.sparse = !!opts.sparse
+  this.indexing = !!opts.indexing
 
   this._checkout = opts._checkout
   this._lock = mutexify()
@@ -398,7 +399,13 @@ Hyperdrive.prototype._loadIndex = function (cb) {
     if (self.content) return self.content.ready(cb)
 
     var keyPair = self.metadata.writable && contentKeyPair(self.metadata.secretKey)
-    var opts = {sparse: self.sparse, maxRequests: self.maxRequests, secretKey: keyPair && keyPair.secretKey, storeSecretKey: false}
+    var opts = {
+      sparse: self.sparse,
+      maxRequests: self.maxRequests,
+      secretKey: keyPair && keyPair.secretKey,
+      storeSecretKey: false,
+      indexing: self.indexing
+    }
 
     self.content = self._checkout ? self._checkout.content : hypercore(self._storages.content, index.content, opts)
     self.content.ready(function (err) {
@@ -442,7 +449,7 @@ Hyperdrive.prototype._open = function (cb) {
 
     if (!self.content) {
       var keyPair = contentKeyPair(self.metadata.secretKey)
-      self.content = hypercore(self._storages.content, keyPair.publicKey, {sparse: self.sparse, secretKey: keyPair.secretKey, storeSecretKey: false})
+      self.content = hypercore(self._storages.content, keyPair.publicKey, {sparse: self.sparse, secretKey: keyPair.secretKey, storeSecretKey: false, indexing: self.indexing})
     }
 
     self.content.ready(function () {


### PR DESCRIPTION
Adds `opts.indexing` to the content feed. 

It didn't seem like this should be added to metadata feed, is that correct?