### PR TITLE
Pass sparse flag to metadata as well as content hypercore

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,10 @@ function Hyperdrive (storage, key, opts) {
 
   this._storages = defaultStorage(this, storage, opts)
 
-  this.metadata = opts.metadata || hypercore(this._storages.metadata, key, {secretKey: opts.secretKey})
+  this.metadata = opts.metadata || hypercore(this._storages.metadata, key, {
+    secretKey: opts.secretKey,
+    sparse: opts.sparse
+  })
   this.content = opts.content || null
   this.maxRequests = opts.maxRequests || 16
   this.readable = true


### PR DESCRIPTION
When replicating to a browser via websockets and storing in indexedDB, performance isn't the best.  It would be nice if the metadata could be sparsely replicated in addition to the content.