### PR TITLE
(WIP) add tests using feed.default to switch indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "unixify": "^1.0.0"
   },
   "devDependencies": {
+    "dat-storage": "^1.0.3",
     "random-access-memory": "^2.3.0",
     "sodium-signatures": "^2.0.0",
     "standard": "^9.0.2",


### PR DESCRIPTION
Adds tests for hypercore indexing switching.

Fixes #160 (kind of). Should I add this as an option to `archive.createWriteStream` also? We could do that by setting the `archive.content.default(writeOpts)` then resetting them.

**WIP**: Requires https://github.com/mafintosh/hypercore/pull/115 to be released