### PR TITLE
Add cache-size opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Options include:
 {
   sparse: true, // only download data on content feed when it is specifically requested
   sparseMetadata: true // only download data on metadata feed when requested
+  metaStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
+  contentStorageCacheSize: 65536 // how many entries to use in the content hypercore's LRU cache
+  treeCacheSize: 65536 // how many entries to use in the append-tree's LRU cache
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options include:
 {
   sparse: true, // only download data on content feed when it is specifically requested
   sparseMetadata: true // only download data on metadata feed when requested
-  metaStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
+  metadataStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
   contentStorageCacheSize: 65536 // how many entries to use in the content hypercore's LRU cache
   treeCacheSize: 65536 // how many entries to use in the append-tree's LRU cache
 }

--- a/index.js
+++ b/index.js
@@ -43,18 +43,25 @@ function Hyperdrive (storage, key, opts) {
   this.metadata = opts.metadata || hypercore(this._storages.metadata, key, {
     secretKey: opts.secretKey,
     sparse: opts.sparseMetadata,
-    createIfMissing: opts.createIfMissing
+    createIfMissing: opts.createIfMissing,
+    storageCacheSize: opts.metaStorageCacheSize
   })
   this.content = opts.content || null
   this.maxRequests = opts.maxRequests || 16
   this.readable = true
 
   this.storage = storage
-  this.tree = tree(this.metadata, {offset: 1, valueEncoding: messages.Stat})
+  this.tree = tree(this.metadata, {
+    offset: 1,
+    valueEncoding: messages.Stat,
+    cache: opts.treeCacheSize !== 0,
+    cacheSize: opts.treeCacheSize
+  })
   if (typeof opts.version === 'number') this.tree = this.tree.checkout(opts.version)
   this.sparse = !!opts.sparse
   this.sparseMetadata = !!opts.sparseMetadata
   this.indexing = !!opts.indexing
+  this.contentStorageCacheSize = opts.contentStorageCacheSize
 
   this._latestSynced = 0
   this._latestVersion = 0
@@ -852,7 +859,8 @@ function contentOptions (self, secretKey) {
     maxRequests: self.maxRequests,
     secretKey: secretKey,
     storeSecretKey: false,
-    indexing: self.metadata.writable && self.indexing
+    indexing: self.metadata.writable && self.indexing,
+    storageCacheSize: self.contentStorageCacheSize
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function Hyperdrive (storage, key, opts) {
     secretKey: opts.secretKey,
     sparse: opts.sparseMetadata,
     createIfMissing: opts.createIfMissing,
-    storageCacheSize: opts.metaStorageCacheSize
+    storageCacheSize: opts.metadataStorageCacheSize
   })
   this.content = opts.content || null
   this.maxRequests = opts.maxRequests || 16

--- a/test/basic.js
+++ b/test/basic.js
@@ -156,3 +156,20 @@ tape('download a version', function (t) {
     stream.pipe(src.replicate()).pipe(stream)
   }
 })
+
+tape('write and read, no cache', function (t) {
+  var archive = create({
+    metaStorageCacheSize: 0,
+    contentStorageCacheSize: 0,
+    treeCacheSize: 0
+  })
+
+  archive.writeFile('/hello.txt', 'world', function (err) {
+    t.error(err, 'no error')
+    archive.readFile('/hello.txt', function (err, buf) {
+      t.error(err, 'no error')
+      t.same(buf, new Buffer('world'))
+      t.end()
+    })
+  })
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -159,7 +159,7 @@ tape('download a version', function (t) {
 
 tape('write and read, no cache', function (t) {
   var archive = create({
-    metaStorageCacheSize: 0,
+    metadataStorageCacheSize: 0,
     contentStorageCacheSize: 0,
     treeCacheSize: 0
   })


### PR DESCRIPTION
Depends on https://github.com/mafintosh/append-tree/pull/10 and https://github.com/mafintosh/hypercore/pull/124

Adds `{metaStorageCacheSize: 65536, contentStorageCacheSize: 65536, treeCacheSize: 65536}` opts to the constructor