### PR TITLE
Add cached and wait opts to stat, lstat, access, and exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Options include:
 ```js
 {
   encoding: string
-  cached: true|false // default: false,
+  cached: true|false // default: false
 }
 ```
 or a string can be passed as options to simply set the encoding - similar to fs.
@@ -221,7 +221,7 @@ Options include:
 
 If `cached` is set to `true`, this function returns results from the local version of the archive’s append-tree. Default behavior is to fetch the latest remote version of the archive before returning list of directories.
 
-#### `archive.stat(name, callback)`
+#### `archive.stat(name, [options], callback)`
 
 Stat an entry. Similar to fs.stat. Sample output:
 
@@ -252,13 +252,49 @@ stat.isDirectory()
 stat.isFile()
 ```
 
-#### `archive.lstat(name, callback)`
+Options include:
+```js
+{
+  cached: true|false // default: false,
+  wait: true|false // default: true
+}
+```
+
+If `cached` is set to `true`, this function returns results only if they have already been downloaded.
+
+If `wait` is set to `true`, this function will wait for data to be downloaded. If false, will return an error.
+
+#### `archive.lstat(name, [options], callback)`
 
 Stat an entry but do not follow symlinks. Similar to fs.lstat.
 
-#### `archive.access(name, callback)`
+Options include:
+```js
+{
+  cached: true|false // default: false,
+  wait: true|false // default: true
+}
+```
+
+If `cached` is set to `true`, this function returns results only if they have already been downloaded.
+
+If `wait` is set to `true`, this function will wait for data to be downloaded. If false, will return an error.
+
+#### `archive.access(name, [options], callback)`
 
 Similar to fs.access.
+
+Options include:
+```js
+{
+  cached: true|false // default: false,
+  wait: true|false // default: true
+}
+```
+
+If `cached` is set to `true`, this function returns results only if they have already been downloaded.
+
+If `wait` is set to `true`, this function will wait for data to be downloaded. If false, will return an error.
 
 #### `archive.open(name, flags, [mode], callback)`
 

--- a/index.js
+++ b/index.js
@@ -663,8 +663,8 @@ Hyperdrive.prototype.mkdir = function (name, opts, cb) {
   })
 }
 
-Hyperdrive.prototype._statDirectory = function (name, cb) {
-  this.tree.list(name, function (err, list) {
+Hyperdrive.prototype._statDirectory = function (name, opts, cb) {
+  this.tree.list(name, opts, function (err, list) {
     if (name !== '/' && (err || !list.length)) return cb(err || new Error(name + ' could not be found'))
     var st = stat()
     st.mode = stat.IFDIR | DEFAULT_DMODE
@@ -672,32 +672,40 @@ Hyperdrive.prototype._statDirectory = function (name, cb) {
   })
 }
 
-Hyperdrive.prototype.access = function (name, cb) {
+Hyperdrive.prototype.access = function (name, opts, cb) {
+  if (typeof opts === 'function') return this.access(name, null, opts)
+  if (!opts) opts = {}
   name = unixify(name)
-  this.stat(name, function (err) {
+  this.stat(name, opts, function (err) {
     cb(err)
   })
 }
 
-Hyperdrive.prototype.exists = function (name, cb) {
-  this.access(name, function (err) {
+Hyperdrive.prototype.exists = function (name, opts, cb) {
+  if (typeof opts === 'function') return this.exists(name, null, opts)
+  if (!opts) opts = {}
+  this.access(name, opts, function (err) {
     cb(!err)
   })
 }
 
-Hyperdrive.prototype.lstat = function (name, cb) {
+Hyperdrive.prototype.lstat = function (name, opts, cb) {
+  if (typeof opts === 'function') return this.lstat(name, null, opts)
+  if (!opts) opts = {}
   var self = this
 
   name = unixify(name)
 
-  this.tree.get(name, function (err, st) {
-    if (err) return self._statDirectory(name, cb)
+  this.tree.get(name, opts, function (err, st) {
+    if (err) return self._statDirectory(name, opts, cb)
     cb(null, stat(st))
   })
 }
 
-Hyperdrive.prototype.stat = function (name, cb) {
-  this.lstat(name, cb)
+Hyperdrive.prototype.stat = function (name, opts, cb) {
+  if (typeof opts === 'function') return this.stat(name, null, opts)
+  if (!opts) opts = {}
+  this.lstat(name, opts, cb)
 }
 
 Hyperdrive.prototype.readdir = function (name, opts, cb) {


### PR DESCRIPTION
Makes it possible to

```js
archive.stat('/', {wait: true}, cb)
```

and/or

```js
archive.stat('/', {cached: true}, cb)
```

They actually have different effects. `cached=true` seems to succeed if the data isnt available if the block represents a folder, while `wait=false` will error no matter what.