### PR TITLE
Add options to checkout()

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ Emitted when the archive is fully ready and all properties has been populated.
 
 Emitted when a critical error during load happened.
 
-#### `var oldDrive = archive.checkout(version)`
+#### `var oldDrive = archive.checkout(version, [opts])`
 
-Checkout a readonly copy of the archive at an old version.
+Checkout a readonly copy of the archive at an old version. Options are used to configure the `oldDrive`:
+
+```js
+{
+  metadataStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
+  contentStorageCacheSize: 65536 // how many entries to use in the content hypercore's LRU cache
+  treeCacheSize: 65536 // how many entries to use in the append-tree's LRU cache
+}
+```
 
 #### `archive.download([path], [callback])`
 

--- a/index.js
+++ b/index.js
@@ -313,12 +313,12 @@ Hyperdrive.prototype.replicate = function (opts) {
   return stream
 }
 
-Hyperdrive.prototype.checkout = function (version) {
-  return Hyperdrive(null, null, {
-    _checkout: this._checkout || this,
-    metadata: this.metadata,
-    version: version
-  })
+Hyperdrive.prototype.checkout = function (version, opts) {
+  if (!opts) opts = {}
+  opts._checkout = this._checkout || this
+  opts.metadata = this.metadata
+  opts.version = version
+  return Hyperdrive(null, null, opts)
 }
 
 Hyperdrive.prototype.createDiffStream = function (version, opts) {


### PR DESCRIPTION
Add options to `checkout()` to configure the new instance

```js
// example
archive.checkout(version, {
  metadataStorageCacheSize: 0,
  contentStorageCacheSize: 0,
  treeCacheSize: 2048
})
```