### PR TITLE
Update FD size during write

### DIFF
--- a/index.js
+++ b/index.js
@@ -588,7 +588,6 @@ class Hyperdrive extends EventEmitter {
           return cb(err)
         }
         if (this._writingFd && name === this._writingFd.path) {
-          console.log('SETTING SIZE TO:', this._writingFd.stat.size)
           st.size = this._writingFd.stat.size
         }
         cb(null, new Stat(st))

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ class Hyperdrive extends EventEmitter {
     this._contentFeedByteLength = null
     this._lock = mutexify()
     this._fds = []
+    this._writingFd = null
 
     this.ready = thunky(this._ready.bind(this))
     this.contentReady = thunky(this._contentReady.bind(this))
@@ -585,6 +586,10 @@ class Hyperdrive extends EventEmitter {
           var st = messages.Stat.decode(node.value)
         } catch (err) {
           return cb(err)
+        }
+        if (this._writingFd && name === this._writingFd.path) {
+          console.log('SETTING SIZE TO:', this._writingFd.stat.size)
+          st.size = this._writingFd.stat.size
         }
         cb(null, new Stat(st))
       })

--- a/index.js
+++ b/index.js
@@ -460,7 +460,7 @@ class Hyperdrive extends EventEmitter {
       }
       this._db.put(name, st, err => {
         if (err) return cb(err)
-        return cb(null)
+        return cb(null, st)
       })
     })
   }

--- a/lib/fd.js
+++ b/lib/fd.js
@@ -71,6 +71,7 @@ class FileDescriptor {
 
     if (!this._writeStream) {
       this._writeStream = createWriteStream(this.drive, this.path)
+      this.drive._writingFd = this
       this._writeStream.on('error', cb)
     }
 
@@ -98,6 +99,7 @@ class FileDescriptor {
       write(self._writeStream, slice, err => {
         if (err) return cb(err)
         self.position += slice.length
+        self.stat.size += slice.length
         return cb(null, slice.length, buffer)
       })
     }
@@ -113,6 +115,7 @@ class FileDescriptor {
 
   close (cb) {
     // TODO: undownload initial range
+    this.drive._writingFd = null
     if (this._writeStream) {
       if (this._writeStream.destroyed) {
         this._writeStream = null

--- a/lib/fd.js
+++ b/lib/fd.js
@@ -253,8 +253,9 @@ module.exports = function create (drive, name, flags, cb) {
 
       const fd = new FileDescriptor(drive, name, st, readable, writable, appending, creating)
       if (creating) {
-        drive.create(name, err => {
+        drive.create(name, (err, st) => {
           if (err) return cb(err)
+          fd.stat = st
           return cb(null, fd)
         })
       } else {


### PR DESCRIPTION
This PR fixes a strange FUSE bug on OSX (`getattr` and `write` get called concurrently, to devastating effect...).