### PR TITLE
fix: allow content feed to be passed in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ class Hyperdrive extends EventEmitter {
     }
 
     function onkey (publicKey) {
-      self.content = self._createHypercore(self._storages.content, publicKey, self._contentOpts)
+      self.content = self.content || self._createHypercore(self._storages.content, publicKey, self._contentOpts)
       self.content.ready(err => {
         if (err) return cb(err)
 


### PR DESCRIPTION
Allows the content feed to be passed in constructor. This allows consumers to control the content feed without extra wrestling with hyperdrive internals.

I'm relying on this for kappa-core multiwriter hyperdrive https://github.com/karissa/peerfs

You *used* to be able to do this last time I checked (2 years ago??) and there is some code hanging around that allows it, I think this just got accidentally overlooked.