### PR TITLE
Added extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options include:
 {
   sparse: true, // only download data on content feed when it is specifically requested
   sparseMetadata: true // only download data on metadata feed when requested
+  extensions: [] // Optionally specify which extensions to use when replicating
   metadataStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
   contentStorageCacheSize: 65536 // how many entries to use in the content hypercore's LRU cache
   treeCacheSize: 65536 // how many entries to use in the append-tree's LRU cache
@@ -122,6 +123,11 @@ Emitted when the archive is fully ready and all properties has been populated.
 
 Emitted when a critical error during load happened.
 
+#### `archive.on('extension', name, message, peer)`
+
+Emitted when a peer sends you an extension message with `archive.extension()`.
+You can respond with `peer.extension(name, message)`.
+
 #### `var oldDrive = archive.checkout(version, [opts])`
 
 Checkout a readonly copy of the archive at an old version. Options are used to configure the `oldDrive`:
@@ -148,6 +154,10 @@ archive.checkout(version).download()
 #### `var stream = archive.history([options])`
 
 Get a stream of all changes and their versions from this archive.
+
+### `archive.extension(name, message)`
+
+Send an extension message to connected peers. [Read more in the hypercore docs](https://github.com/mafintosh/hypercore#feedextensionname-message).
 
 #### `var stream = archive.createReadStream(name, [options])`
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function Hyperdrive (storage, key, opts) {
     sparse: opts.sparseMetadata,
     createIfMissing: opts.createIfMissing,
     storageCacheSize: opts.metadataStorageCacheSize,
-    extensions: opts.extensions,
+    extensions: opts.extensions
   })
   this.content = opts.content || null
   this.maxRequests = opts.maxRequests || 16

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function Hyperdrive (storage, key, opts) {
   var self = this
 
   this.metadata.on('append', update)
+  this.metadata.on('extension', extension)
   this.metadata.on('error', onerror)
   this.ready = thunky(open)
   this.ready(onready)
@@ -98,6 +99,10 @@ function Hyperdrive (storage, key, opts) {
 
   function update () {
     self.emit('update')
+  }
+
+  function extension (name, message, peer) {
+    self.emit('extension', name, message, peer)
   }
 
   function open (cb) {
@@ -873,6 +878,10 @@ Hyperdrive.prototype._open = function (cb) {
       self.metadata.append(messages.Index.encode({type: 'hyperdrive', content: self.content.key}), cb)
     })
   }
+}
+
+Hyperdrive.prototype.extension = function (name, message) {
+  this.metadata.extension(name, message)
 }
 
 function contentOptions (self, secretKey) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ function Hyperdrive (storage, key, opts) {
     secretKey: opts.secretKey,
     sparse: opts.sparseMetadata,
     createIfMissing: opts.createIfMissing,
-    storageCacheSize: opts.metadataStorageCacheSize
+    storageCacheSize: opts.metadataStorageCacheSize,
+    extensions: opts.extensions,
   })
   this.content = opts.content || null
   this.maxRequests = opts.maxRequests || 16

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "append-tree": "^2.3.5",
     "duplexify": "^3.5.0",
     "from2": "^2.3.0",
-    "hypercore": "github:mafintosh/hypercore",
+    "hypercore": "^7.5.0",
     "inherits": "^2.0.3",
     "mutexify": "^1.1.0",
     "protocol-buffers-encodings": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "append-tree": "^2.3.5",
     "duplexify": "^3.5.0",
     "from2": "^2.3.0",
-    "hypercore": "^6.22.1",
+    "hypercore": "github:mafintosh/hypercore",
     "inherits": "^2.0.3",
     "mutexify": "^1.1.0",
     "protocol-buffers-encodings": "^1.1.0",

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -18,18 +18,17 @@ tape('send and receive extension messages', function (t) {
     })
 
     drive2.ready(function () {
-
       const replicate1 = drive1.replicate()
       const replicate2 = drive2.replicate()
 
       drive2.on('extension', function (type, message) {
-         t.equal(type, EXAMPLE_TYPE)
-         t.equal(message.toString('hex'), EXAMPLE_MESSAGE.toString('hex'))
-       })
+        t.equal(type, EXAMPLE_TYPE)
+        t.equal(message.toString('hex'), EXAMPLE_MESSAGE.toString('hex'))
+      })
 
-       drive1.metadata.on('peer-add', function () {
-         drive1.extension(EXAMPLE_TYPE, EXAMPLE_MESSAGE)
-       })
+      drive1.metadata.on('peer-add', function () {
+        drive1.extension(EXAMPLE_TYPE, EXAMPLE_MESSAGE)
+      })
 
       replicate1.pipe(replicate2).pipe(replicate1)
     })

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,0 +1,37 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+
+var EXAMPLE_TYPE = 'example'
+var EXTENSIONS = [EXAMPLE_TYPE]
+var EXAMPLE_MESSAGE = Buffer.from([4, 20])
+
+tape('send and receive extension messages', function (t) {
+  var drive1 = create(null, {
+    extensions: EXTENSIONS
+  })
+
+  drive1.ready(function () {
+    t.plan(2)
+
+    var drive2 = create(drive1.key, {
+      extensions: EXTENSIONS
+    })
+
+    drive2.ready(function () {
+
+      const replicate1 = drive1.replicate()
+      const replicate2 = drive2.replicate()
+
+      drive2.on('extension', function (type, message) {
+         t.equal(type, EXAMPLE_TYPE)
+         t.equal(message.toString('hex'), EXAMPLE_MESSAGE.toString('hex'))
+       })
+
+       drive1.metadata.on('peer-add', function () {
+         drive1.extension(EXAMPLE_TYPE, EXAMPLE_MESSAGE)
+       })
+
+      replicate1.pipe(replicate2).pipe(replicate1)
+    })
+  })
+})


### PR DESCRIPTION
Following up on [the hypercore extension support](https://github.com/mafintosh/hypercore/pull/214), this surfaces the extensions API in hyperdrive so that applications can build on top of it.

This could simplify code for things like Beaker's [datPeers](https://beakerbrowser.com/docs/apis/experimental-datpeers) API.

Adds:

- `extensions` option in constructor that gets passed to the metadata hypercore
- `extension` method for sending an extension message to all peers

TODO:

- [x] Tests
- [x] Docs

Should I maybe redo this PR against the v10 branch, or could we get it into a v9 release before then?