### PR TITLE
Emit close event on archive close

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Emitted when the archive is fully ready and all properties has been populated.
 
 Emitted when a critical error during load happened.
 
+#### `archive.on('close')`
+
+Emitted when the archive has been closed
+
 #### `archive.on('extension', name, message, peer)`
 
 Emitted when a peer sends you an extension message with `archive.extension()`.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ A boolean indicating whether the archive is writable.
 
 Emitted when the archive is fully ready and all properties has been populated.
 
+#### `archive.on('update')'
+
+Emitted when the archive has got a new change.
+
 #### `archive.on('error', err)`
 
 Emitted when a critical error during load happened.

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function Hyperdrive (storage, key, opts) {
   this.metadata.on('append', update)
   this.metadata.on('extension', extension)
   this.metadata.on('error', onerror)
+  this.metadata.once('close', onclose)
   this.ready = thunky(open)
   this.ready(onready)
 
@@ -96,6 +97,10 @@ function Hyperdrive (storage, key, opts) {
 
   function onerror (err) {
     if (err) self.emit('error', err)
+  }
+
+  function onclose () {
+    self.emit('close')
   }
 
   function update () {

--- a/test/basic.js
+++ b/test/basic.js
@@ -204,3 +204,13 @@ tape('no .. entries', function (t) {
     })
   })
 })
+
+tape('closing emits event', function (t) {
+  var archive = create()
+
+  archive.on('close', function () {
+    t.end()
+  })
+
+  archive.close()
+})


### PR DESCRIPTION
It can be a little frustrating to manage hyperdrives (for example in the SDK) when you don't know when an application will be closing them.

This PR propagates the `close` event from the metadata hypercore to the hyperdrive.