### PR TITLE
Added sync-metadata event

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ A boolean indicating whether the archive is writable.
 
 Emitted when the archive is fully ready and all properties has been populated.
 
+#### `archive.on('update')`
+
+Emitted when new file changes are detected.
+
+#### `archive.on('sync-metadata')`
+
+Emitted when the archive has fully synced it's metadata with a remote peer.
+
+You should listen on this if you're trying to use `readdir` on a new archive.
+
 #### `archive.on('error', err)`
 
 Emitted when a critical error during load happened.

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ function Hyperdrive (storage, key, opts) {
 
   this.metadata.on('append', update)
   this.metadata.on('extension', extension)
+  this.metadata.on('sync', onsync)
   this.metadata.on('error', onerror)
   this.ready = thunky(open)
   this.ready(onready)
@@ -100,6 +101,10 @@ function Hyperdrive (storage, key, opts) {
 
   function update () {
     self.emit('update')
+  }
+
+  function onsync () {
+    self.emit('sync-metadata')
   }
 
   function extension (name, message, peer) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -57,6 +57,27 @@ tape('write and read (sparse)', function (t) {
   })
 })
 
+tape('update and sync', function (t) {
+  t.plan(2)
+
+  var archive = create()
+
+  archive.ready(function () {
+    var clone = create(archive.key)
+
+    clone.on('update', function () {
+      t.pass('updated')
+    })
+
+    clone.on('sync-metadata', function () {
+      t.pass('synced')
+    })
+
+    var stream = clone.replicate()
+    stream.pipe(archive.replicate()).pipe(stream)
+  })
+})
+
 tape('write and unlink', function (t) {
   var archive = create()
 


### PR DESCRIPTION
This is useful for people to know when it's safe to use `readdir` and the such.

Currently people use a bunch of weird tricks to get it to work. 

This will make the tricks a little bit less arcane and somewhat documented. :P