### PR TITLE
Added events and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hyperdrive
 
 #### *Note*: This is a prerelease version of Hyperdrive that's backed by [Hypertrie](https://github.com/mafintosh/hypertrie)
-#### This version is not yet API-complete. 
+#### This version is not yet API-complete.
 
 Hyperdrive is a secure, real time distributed file system
 
@@ -83,6 +83,7 @@ Options include:
   sparseMetadata: true // only download data on metadata feed when requested
   metadataStorageCacheSize: 65536 // how many entries to use in the metadata hypercore's LRU cache
   contentStorageCacheSize: 65536 // how many entries to use in the content hypercore's LRU cache
+  extensions: [], // The list of extension message types to use
 }
 ```
 
@@ -116,6 +117,10 @@ A key derived from the public key that can be used to discovery other peers shar
 
 A boolean indicating whether the archive is writable.
 
+#### `archive.peers`
+
+A list of peers currently replicating with this archive
+
 #### `archive.on('ready')`
 
 Emitted when the archive is fully ready and all properties has been populated.
@@ -123,6 +128,44 @@ Emitted when the archive is fully ready and all properties has been populated.
 #### `archive.on('error', err)`
 
 Emitted when a critical error during load happened.
+
+#### `archive.on('update')`
+
+Emitted when there is a new update to the archive.
+
+#### `archive.on('extension', name, message, peer)`
+
+Emitted when a peer has sent you an extension message. The `name` is a string from one of the extension types in the constructor, `message` is a buffer containing the message contents, and `peer` is a reference to the peer that sent the extension. You can send an extension back with `peer.extension(name, message)`.
+
+#### `archive.on('peer-add', peer)`
+
+Emitted when a new peer has been added.
+
+```js
+const archive = Hyperdrive({
+  extension: ['example']
+})
+
+archive.on('extension', (name, message, peer) => {
+  console.log(name, message.toString('utf8'))
+})
+
+archive.on('peer-add', (peer) => {
+  peer.extension('example', Buffer.from('Hello World!', 'utf8'))
+})
+```
+
+#### `archive.on('peer-remove', peer)`
+
+Emitted when a peer has been removed.
+
+#### `archive.on('close')`
+
+Emitted when the archive has been closed.
+
+#### `archive.extension(name, message)`
+
+Broadcasts an extension message to all connected peers. The `name` must be a string for an extension passed in the constructor and the message must be a buffer.
 
 #### `var oldDrive = archive.checkout(version, [opts])`
 

--- a/index.js
+++ b/index.js
@@ -47,14 +47,14 @@ class Hyperdrive extends EventEmitter {
       valueEncoding: 'binary',
       // TODO: Support mixed sparsity.
       sparse: this.sparse || this.sparseMetadata,
-      extensions: optis.extensions,
+      extensions: opts.extensions
     })
 
     const metadataOpts = {
       key,
       sparse: this.sparseMetadata,
       secretKey: (opts.keyPair) ? opts.keyPair.secretKey : opts.secretKey,
-      extensions: optis.extensions,
+      extensions: opts.extensions
     }
 
     if (storage instanceof Corestore && storage.isDefaultSet()) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,21 @@ var tape = require('tape')
 var sodium = require('sodium-universal')
 var create = require('./helpers/create')
 
+tape('close event', function (t) {
+  t.plan(1)
+
+  var drive = create()
+
+  drive.on('close', function () {
+    t.pass('close event')
+    t.end()
+  })
+
+  drive.ready(function () {
+    drive.close()
+  })
+})
+
 tape('write and read', function (t) {
   var drive = create()
 

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,0 +1,37 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+
+var EXAMPLE_TYPE = 'example'
+var EXTENSIONS = [EXAMPLE_TYPE]
+var EXAMPLE_MESSAGE = Buffer.from([4, 20])
+
+tape('send and receive extension messages', function (t) {
+  var drive1 = create(null, {
+    extensions: EXTENSIONS
+  })
+
+  drive1.ready(function () {
+    t.plan(3)
+
+    var drive2 = create(drive1.key, {
+      extensions: EXTENSIONS
+    })
+
+    drive2.ready(function () {
+      const replicate1 = drive1.replicate()
+      const replicate2 = drive2.replicate()
+
+      drive2.on('extension', function (type, message) {
+        t.equal(type, EXAMPLE_TYPE, 'got expected type')
+        t.equal(message.toString('hex'), EXAMPLE_MESSAGE.toString('hex'), 'got expected message')
+      })
+
+      drive1.on('peer-add', function () {
+        t.pass('got peer add event')
+        drive1.extension(EXAMPLE_TYPE, EXAMPLE_MESSAGE)
+      })
+
+      replicate1.pipe(replicate2).pipe(replicate1)
+    })
+  })
+})


### PR DESCRIPTION
Adds the following:

- Added `extensions` array to constructor to be passed down to the metadata core
- `"extension"` event from the metadata feed to listen on extension messages
- `extension()` method for broadcasting extension messages to peers
- `.peers` getter for getting the current list of peers (useful for stuff like getting the health of an archive)
- `"peer-add"` event from the metadata feed so that actions can be taken when a peer is added (useful for extension stuff)
- `"peer-remove"` event from the metadata feed so that actions can be taken when a peer is removed
- `"close"` event so that actions can be taken when the archive is closed (useful for the SDK)
- docs for the `"update"` event so that people can be aware of it

Ideally these properties and events should be exposed in the RPC API in the daemon down the line, which is why I'd like to surface them at the top level rather than getting people to mess with the metadata feed directly.

TODO:

- Tests 😁