### PR TITLE
Add seqs to diffStream entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,9 @@ class Hyperdrive extends EventEmitter {
     return pumpify.obj(
       diffStream,
       through.obj((chunk, enc, cb) => {
-        let entry = { type: chunk.type, name: chunk.key }
+        const entry = { type: chunk.type, name: chunk.key }
+        if (chunk.left) entry.seq = chunk.left.seq
+        if (chunk.right) entry.previous = { seq: chunk.right.seq }
         if (chunk.left && entry.type !== 'mount' && entry.type !== 'unmount') {
           try {
             entry.value = Stat.decode(chunk.left.value)

--- a/test/diff.js
+++ b/test/diff.js
@@ -98,7 +98,7 @@ tape('diff stream with mounts', async function (t) {
   }
 })
 
-tape.only('diff stream returns seqs', t => {
+tape('diff stream returns seqs', t => {
   const drive = create()
   runAll([
     cb => drive.writeFile('one', Buffer.from('one'), cb),
@@ -119,12 +119,12 @@ tape.only('diff stream returns seqs', t => {
     cb => drive.writeFile('three', Buffer.from('three'), cb),
     cb => drive.unlink('one', cb),
     cb => {
-      const diff = drive.createDiffStream(3)
+      const diff = drive.createDiffStream(4)
       collect(diff, (err, res) => {
         t.error(err)
         res = res.map(map)
         t.deepEqual(res, [
-          'del one x 1',
+          'del one x 3',
           'put three 5 x'
         ], 'seqs are correct')
         t.end()


### PR DESCRIPTION
This adds the seq numbers to the diffstream. The data is already there from hypertrie's diff method but not exposed currently. It's great to have for all kinds of kappa-style secondary indexes, and I don't see a reason not to have it if its there already.