### PR TITLE
FD close cancels pending reads

### DIFF
--- a/lib/fd.js
+++ b/lib/fd.js
@@ -118,7 +118,6 @@ class FileDescriptor {
   }
 
   close (cb) {
-    // TODO: undownload initial range
     // TODO: If we ever support multiple file descriptors for one path at one time, this will need updating.
     if (this.writable) this.drive._writingFds.delete(this.path)
     if (this._writeStream) {
@@ -134,6 +133,8 @@ class FileDescriptor {
     }
     if (this._range) {
       this.contentState.feed.undownload(this._range)
+      // TODO: Ensure that the range being cancelled isn't being read by another operation.
+      this.contentState.feed.cancel(this._range.start, this._range.end)
       this._range = null
     }
     process.nextTick(cb, null)

--- a/test/fd.js
+++ b/test/fd.js
@@ -420,10 +420,8 @@ tape('fd close cancels pending reads', function (t) {
         })
         setImmediate(() => {
           // This should cancel the above read.
-          console.log('closing')
           clone.close(descriptor, err => {
             t.error(err, 'no error')
-            console.log('finished close')
             t.false(totalRead)
           })
         })


### PR DESCRIPTION
When a file descriptor is closed, it should cancel all pending download ranges, which should in turn trigger cancellation errors for all pending reads. This is particularly important for FUSE, as it will prevent hanging terminals etc after a program exits before reads could complete.