### PR TITLE
added destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,3 +389,8 @@ Close a file. Similar to fs.close.
 
 Closes all open resources used by the archive.
 The archive should no longer be used after calling this.
+
+#### `archive.destroy([callback])
+
+Closes the archive and destroys all its data from disk.
+Useful for clearing data you don't want anymore.

--- a/index.js
+++ b/index.js
@@ -806,6 +806,18 @@ class Hyperdrive extends Nanoresource {
     super.close(false, fd)
   }
 
+  destroy (cb) {
+    if (!cb) cb = noop
+
+	// We need to destroy the corestore before closing
+	// Otherwise we'll lose references to the cores
+    this.corestore.destroy((err) => {
+      if (err) return cb(err)
+      this.emit('destroyed')
+      this.close(cb)
+    })
+  }
+
   stats (path, opts, cb) {
     if (typeof opts === 'function') return this.stats(path, null, opts)
     const self = this

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/mafintosh/hyperdrive#readme",
   "dependencies": {
     "byte-stream": "^2.1.0",
-    "corestore": "^5.0.0",
+    "corestore": "github:rangermauve/corestore#delete-method",
     "custom-error-class": "^1.0.0",
     "duplexify": "^3.7.1",
     "filesystem-constants": "^1.0.0",

--- a/test/storage.js
+++ b/test/storage.js
@@ -139,3 +139,26 @@ tape('sparse read/write two files', function (t) {
     }
   })
 })
+
+tape('destroying archives', function (t) {
+  tmp(function (err, dir, cleanup) {
+    t.ifError(err)
+    var drive = hyperdrive(dir)
+
+    drive.writeFile('/hello.txt', 'hello world', function (err) {
+      t.ifError(err)
+      drive.destroy(function (err) {
+        t.ifError(err)
+        var drive2 = hyperdrive(dir)
+        drive2.ready(function (err) {
+          t.ifError(err)
+          drive2.readdir('/', function (err, files) {
+            t.ifError(err)
+            t.same(files, [], 'drive contents were destroyed')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds a destroy method to hyperdrive which deletes its underlying data.

Same as the method in hypercore and [corestore](https://github.com/andrewosh/corestore/pull/9).