### PR TITLE
Note that purge() is unimplemented in Hypercore 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ A `blobs: <length>` option can be passed in if you know the corresponding blobs 
 
 #### `await drive.purge()`
 
-Purge both cores (db and blobs) from your storage, completely removing all the drive's data.
+Purge both cores (db and blobs) from your storage, completely removing all the drive's data. Currently unimplemented in Hypercore 11.
 
 #### `await drive.symlink(path, linkname)`
 


### PR DESCRIPTION
Removed when Hypercore [refactored to use rocksdb](https://github.com/holepunchto/hypercore/commit/95aea2c62a0197f75e0c16212796a6f109fe64d1#diff-826e5ed9069c92baa50ec46dde8074a6789b4c90837c5ede0e6b0438e3c34309L558). In the hypercore code base the tests are [commented out with a 'TODO'](https://github.com/holepunchto/hypercore/blob/43b1143cab7a2db60fd4af7da8e25421272d6f1b/test/all.js#L25).