### PR TITLE
Prefetch db core before totalling length in `getBlobsLength()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -763,6 +763,10 @@ function generateContentManifest(m, key) {
 async function getBlobsLength(db) {
   let length = 0
 
+  // Prefetch db core
+  await db.ready() // Ensure length is loaded
+  await db.core.download({ start: 0, end: db.core.length }).done()
+
   for await (const { value } of db.createReadStream()) {
     const b = value && value.blob
     if (!b) continue

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bare-path": "^3.0.0",
     "brittle": "^3.1.0",
     "corestore": "^7.0.0",
+    "debugging-stream": "^3.1.0",
     "hypercore-crypto": "^3.4.0",
     "hyperdht": "^6.6.0",
     "hyperswarm": "^4.0.0",

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ const Hyperswarm = require('hyperswarm')
 const b4a = require('b4a')
 const getTmpDir = require('test-tmp')
 const unixPathResolve = require('unix-path-resolve')
+const safetyCatch = require('safety-catch')
 const Hyperdrive = require('./index.js')
 
 test('drive.core', async (t) => {
@@ -1499,6 +1500,36 @@ test('getBlobsLength of empty drive', async (t) => {
   await corestore.close()
 })
 
+test('getBlobsLength large db - prefetch', async (t) => {
+  const store = new Corestore(await t.tmp())
+  t.teardown(() => store.close())
+  const a = new Hyperdrive(store.session())
+  t.teardown(() => a.close())
+
+  for (let i = 0; i < 50_000; i++) {
+    await a.put('./file' + i, 'here')
+  }
+
+  const store2 = new Corestore(await t.tmp())
+  t.teardown(() => store2.close())
+  const b = new Hyperdrive(store2.session(), a.key)
+  t.teardown(() => b.close())
+
+  const start = Date.now()
+
+  const gotAppend = once(b.core, 'append')
+  replicateDirect(t, a, b)
+  await gotAppend
+
+  const bBlobsLength = await b.getBlobsLength()
+  const end = Date.now()
+
+  t.is(bBlobsLength, await a.getBlobsLength(), 'blob lengths match')
+
+  t.comment('getBlobsLength() time in secs ' + (end - start) / 1000)
+  t.ok(end - start < 5_000, 'synced in a reasonable time')
+})
+
 test('truncate happy path', async (t) => {
   const corestore = new Corestore(await t.tmp())
   const drive = new Hyperdrive(corestore.session())
@@ -1931,6 +1962,36 @@ async function replicate(drive, swarm, mirror) {
   mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
   mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
   await mirror.swarm.flush()
+}
+
+async function replicateDirect(t, a, b, opts = {}) {
+  const s1 = a.replicate(true, { keepAlive: false, ...opts })
+  const s2 = b.replicate(false, { keepAlive: false, ...opts })
+
+  const closed1 = new Promise((resolve) => s1.once('close', resolve))
+  const closed2 = new Promise((resolve) => s2.once('close', resolve))
+
+  s1.on('error', (err) => {
+    safetyCatch(err)
+    t.comment(`replication stream error (initiator): ${err}`)
+  })
+  s2.on('error', (err) => {
+    safetyCatch(err)
+    t.comment(`replication stream error (responder): ${err}`)
+  })
+
+  if (opts.teardown !== false) {
+    t.teardown(async function () {
+      s1.destroy()
+      s2.destroy()
+      await closed1
+      await closed2
+    })
+  }
+
+  s1.pipe(s2).pipe(s1)
+
+  return [s1, s2]
 }
 
 async function ensureDbLength(drive, length) {

--- a/test.js
+++ b/test.js
@@ -1527,7 +1527,7 @@ test('getBlobsLength large db - prefetch', async (t) => {
   t.is(bBlobsLength, await a.getBlobsLength(), 'blob lengths match')
 
   t.comment('getBlobsLength() time in secs ' + (end - start) / 1000)
-  t.ok(end - start < 1_000, 'synced in a reasonable time')
+  t.ok(end - start < 2_000, 'synced in a reasonable time')
 })
 
 test('truncate happy path', async (t) => {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ const Hyperswarm = require('hyperswarm')
 const b4a = require('b4a')
 const getTmpDir = require('test-tmp')
 const unixPathResolve = require('unix-path-resolve')
-const safetyCatch = require('safety-catch')
+const DebuggingStream = require('debugging-stream')
 const Hyperdrive = require('./index.js')
 
 test('drive.core', async (t) => {
@@ -1500,13 +1500,13 @@ test('getBlobsLength of empty drive', async (t) => {
   await corestore.close()
 })
 
-test('getBlobsLength large db - prefetch', { timeout: 40_000 }, async (t) => {
+test('getBlobsLength large db - prefetch', async (t) => {
   const store = new Corestore(await t.tmp())
   t.teardown(() => store.close())
   const a = new Hyperdrive(store.session())
   t.teardown(() => a.close())
 
-  for (let i = 0; i < 30_000; i++) {
+  for (let i = 0; i < 1_000; i++) {
     await a.put('./file' + i, 'here')
   }
 
@@ -1518,7 +1518,7 @@ test('getBlobsLength large db - prefetch', { timeout: 40_000 }, async (t) => {
   const start = Date.now()
 
   const gotAppend = once(b.core, 'append')
-  replicateDirect(t, a, b)
+  replicateDebugStream(t, a, b, { latency: 10 })
   await gotAppend
 
   const bBlobsLength = await b.getBlobsLength()
@@ -1527,7 +1527,7 @@ test('getBlobsLength large db - prefetch', { timeout: 40_000 }, async (t) => {
   t.is(bBlobsLength, await a.getBlobsLength(), 'blob lengths match')
 
   t.comment('getBlobsLength() time in secs ' + (end - start) / 1000)
-  t.ok(end - start < 4_000, 'synced in a reasonable time')
+  t.ok(end - start < 1_000, 'synced in a reasonable time')
 })
 
 test('truncate happy path', async (t) => {
@@ -1964,28 +1964,30 @@ async function replicate(drive, swarm, mirror) {
   await mirror.swarm.flush()
 }
 
-async function replicateDirect(t, a, b, opts = {}) {
+function replicateDebugStream(t, a, b, opts = {}) {
+  const { latency, speed, jitter } = opts
+
   const s1 = a.replicate(true, { keepAlive: false, ...opts })
-  const s2 = b.replicate(false, { keepAlive: false, ...opts })
+  const s2Base = b.replicate(false, { keepAlive: false, ...opts })
+  const s2 = new DebuggingStream(s2Base, { latency, speed, jitter })
 
-  const closed1 = new Promise((resolve) => s1.once('close', resolve))
-  const closed2 = new Promise((resolve) => s2.once('close', resolve))
-
-  s1.on('error', (err) => {
-    safetyCatch(err)
-    t.comment(`replication stream error (initiator): ${err}`)
-  })
-  s2.on('error', (err) => {
-    safetyCatch(err)
-    t.comment(`replication stream error (responder): ${err}`)
-  })
+  s1.on('error', (err) => t.comment(`replication stream error (initiator): ${err}`))
+  s2.on('error', (err) => t.comment(`replication stream error (responder): ${err}`))
 
   if (opts.teardown !== false) {
     t.teardown(async function () {
-      s1.destroy()
-      s2.destroy()
-      await closed1
-      await closed2
+      let missing = 2
+      await new Promise((resolve) => {
+        s1.on('close', onclose)
+        s1.destroy()
+
+        s2.on('close', onclose)
+        s2.destroy()
+
+        function onclose() {
+          if (--missing === 0) resolve()
+        }
+      })
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -1500,13 +1500,13 @@ test('getBlobsLength of empty drive', async (t) => {
   await corestore.close()
 })
 
-test('getBlobsLength large db - prefetch', async (t) => {
+test('getBlobsLength large db - prefetch', { timeout: 40_000 }, async (t) => {
   const store = new Corestore(await t.tmp())
   t.teardown(() => store.close())
   const a = new Hyperdrive(store.session())
   t.teardown(() => a.close())
 
-  for (let i = 0; i < 50_000; i++) {
+  for (let i = 0; i < 30_000; i++) {
     await a.put('./file' + i, 'here')
   }
 
@@ -1527,7 +1527,7 @@ test('getBlobsLength large db - prefetch', async (t) => {
   t.is(bBlobsLength, await a.getBlobsLength(), 'blob lengths match')
 
   t.comment('getBlobsLength() time in secs ' + (end - start) / 1000)
-  t.ok(end - start < 5_000, 'synced in a reasonable time')
+  t.ok(end - start < 4_000, 'synced in a reasonable time')
 })
 
 test('truncate happy path', async (t) => {

--- a/test.js
+++ b/test.js
@@ -1502,7 +1502,6 @@ test('getBlobsLength of empty drive', async (t) => {
 
 test('getBlobsLength large db - prefetch', async (t) => {
   const store = new Corestore(await t.tmp())
-  t.teardown(() => store.close())
   const a = new Hyperdrive(store.session())
   t.teardown(() => a.close())
 
@@ -1511,7 +1510,6 @@ test('getBlobsLength large db - prefetch', async (t) => {
   }
 
   const store2 = new Corestore(await t.tmp())
-  t.teardown(() => store2.close())
   const b = new Hyperdrive(store2.session(), a.key)
   t.teardown(() => b.close())
 

--- a/test.js
+++ b/test.js
@@ -1504,6 +1504,7 @@ test('getBlobsLength large db - prefetch', async (t) => {
   const store = new Corestore(await t.tmp())
   t.teardown(() => store.close())
   const a = new Hyperdrive(store.session())
+  t.teardown(() => a.close())
 
   for (let i = 0; i < 1_000; i++) {
     await a.put('./file' + i, 'here')
@@ -1512,6 +1513,7 @@ test('getBlobsLength large db - prefetch', async (t) => {
   const store2 = new Corestore(await t.tmp())
   t.teardown(() => store2.close())
   const b = new Hyperdrive(store2.session(), a.key)
+  t.teardown(() => b.close())
 
   const start = Date.now()
 

--- a/test.js
+++ b/test.js
@@ -1502,16 +1502,16 @@ test('getBlobsLength of empty drive', async (t) => {
 
 test('getBlobsLength large db - prefetch', async (t) => {
   const store = new Corestore(await t.tmp())
+  t.teardown(() => store.close())
   const a = new Hyperdrive(store.session())
-  t.teardown(() => a.close())
 
   for (let i = 0; i < 1_000; i++) {
     await a.put('./file' + i, 'here')
   }
 
   const store2 = new Corestore(await t.tmp())
+  t.teardown(() => store2.close())
   const b = new Hyperdrive(store2.session(), a.key)
-  t.teardown(() => b.close())
 
   const start = Date.now()
 


### PR DESCRIPTION
Prefetching dramatically speeds up calculating the blobs length for large hyperdrives. It means more blocks are downloaded but the hyperbee blocks are relatively small and worth the tradeoff for speed.

The checkout needs to be `ready()`'ed because the length hasn't loaded yet by the time the prefetch is called.