### PR TITLE
Track whether `path` falling through `has()` had sub entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,13 +475,15 @@ module.exports = class Hyperdrive extends ReadyResource {
       if (!b) return false
       return await blobs.core.has(b.blockOffset, b.blockOffset + b.blockLength)
     }
+    let isDir = false
     for await (const entry of this.list(path)) {
+      isDir = true
       const b = entry.value.blob
       if (!b) continue
       const has = await blobs.core.has(b.blockOffset, b.blockOffset + b.blockLength)
       if (!has) return false
     }
-    return true
+    return isDir
   }
 
   // atm always recursive, but we should add some depth thing to it

--- a/test.js
+++ b/test.js
@@ -819,7 +819,7 @@ test('drive.downloadDiff(version, folder, [options])', async (t) => {
 })
 
 test('drive.has(path)', async (t) => {
-  t.plan(7)
+  t.plan(8)
   const { corestore, drive, swarm, mirror } = await testenv(t)
   swarm.on('connection', (conn) => corestore.replicate(conn))
   swarm.join(drive.discoveryKey, { server: true, client: false })
@@ -839,6 +839,7 @@ test('drive.has(path)', async (t) => {
   t.absent(await mirror.drive.has('/parent/child/'))
   t.absent(await mirror.drive.has('/parent/child/grandchild2'))
   t.absent(await mirror.drive.has('/non-existent.txt'), 'returns false for non-existent files')
+  t.absent(await mirror.drive.has('/non-existent/'), 'returns false for non-existent directory')
 
   await drive.put('/parent/sibling/grandchild1', nil)
 

--- a/test.js
+++ b/test.js
@@ -819,7 +819,7 @@ test('drive.downloadDiff(version, folder, [options])', async (t) => {
 })
 
 test('drive.has(path)', async (t) => {
-  t.plan(6)
+  t.plan(7)
   const { corestore, drive, swarm, mirror } = await testenv(t)
   swarm.on('connection', (conn) => corestore.replicate(conn))
   swarm.join(drive.discoveryKey, { server: true, client: false })
@@ -838,6 +838,7 @@ test('drive.has(path)', async (t) => {
 
   t.absent(await mirror.drive.has('/parent/child/'))
   t.absent(await mirror.drive.has('/parent/child/grandchild2'))
+  t.absent(await mirror.drive.has('/non-existent.txt'), 'returns false for non-existent files')
 
   await drive.put('/parent/sibling/grandchild1', nil)
 


### PR DESCRIPTION
Previously it was assumed that if a `path` got to this point, the `path` was a directory (eg. `/dir`). But if there are no entries then it can't be asserted. In addition file paths (eg `/non-existent.txt`) would return true.

This adds a test for a non-existent `path` returning `false` and a fix by detecting if any entry was found before asserting `path` was a directory.