### PR TITLE
Monitor Fix

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -11,8 +11,10 @@ module.exports = class Monitor extends ReadyResource {
     this.entry = opts.entry || null
     this.peers = 0
 
-    this._boundOnUpload = this._onUpload.bind(this)
-    this._boundOnDownload = this._onDownload.bind(this)
+    this._boundOnBlobUpload = this._onUpload.bind(this, false)
+    this._boundOnBlobDownload = this._onDownload.bind(this, false)
+    this._boundOnDbUpload = this._onUpload.bind(this, true)
+    this._boundOnDbDownload = this._onDownload.bind(this, true)
     this._boundPeerUpdate = this._updatePeers.bind(this)
 
     const stats = {
@@ -22,6 +24,8 @@ module.exports = class Monitor extends ReadyResource {
       speed: 0,
       blocks: 0,
       totalBytes: 0, // local + bytes loaded during monitoring
+      dbBytes: 0, // bytes loaded from the db / preload
+      blobBytes: 0, // bytes loaded from the blobs core
       monitoringBytes: 0, // bytes loaded during monitoring
       targetBytes: 0,
       targetBlocks: 0
@@ -40,8 +44,6 @@ module.exports = class Monitor extends ReadyResource {
   async _open() {
     await this.drive.ready()
     this.blobs = await this.drive.getBlobs()
-    if (!this.entry && this.name) this.entry = await this.drive.entry(this.name)
-    if (this.entry) this._setEntryInfo()
 
     this.uploadSpeedometer = speedometer()
     this.downloadSpeedometer = speedometer()
@@ -51,29 +53,28 @@ module.exports = class Monitor extends ReadyResource {
     // Handlers
     this.blobs.core.on('peer-add', this._boundPeerUpdate)
     this.blobs.core.on('peer-remove', this._boundPeerUpdate)
-    this.blobs.core.on('upload', this._boundOnUpload)
-    this.blobs.core.on('download', this._boundOnDownload)
+    this.blobs.core.on('upload', this._boundOnBlobUpload)
+    this.blobs.core.on('download', this._boundOnBlobDownload)
 
-    if (!this.entry) {
-      this.drive.db.core.on('peer-add', this._boundPeerUpdate)
-      this.drive.db.core.on('peer-remove', this._boundPeerUpdate)
-      this.drive.db.core.on('upload', this._boundOnUpload)
-      this.drive.db.core.on('download', this._boundOnDownload)
-    }
+    this.drive.db.core.on('peer-add', this._boundPeerUpdate)
+    this.drive.db.core.on('peer-remove', this._boundPeerUpdate)
+    this.drive.db.core.on('upload', this._boundOnDbUpload)
+    this.drive.db.core.on('download', this._boundOnDbDownload)
+
+    if (!this.entry && this.name) this.entry = await this.drive.entry(this.name)
+    if (this.entry) this._setEntryInfo()
   }
 
   async _close() {
     this.blobs.core.off('peer-add', this._boundPeerUpdate)
     this.blobs.core.off('peer-remove', this._boundPeerUpdate)
-    this.blobs.core.off('upload', this._boundOnUpload)
-    this.blobs.core.off('download', this._boundOnDownload)
+    this.blobs.core.off('upload', this._boundOnBlobUpload)
+    this.blobs.core.off('download', this._boundOnBlobDownload)
 
-    if (!this.entry) {
-      this.drive.db.core.off('peer-add', this._boundPeerUpdate)
-      this.drive.db.core.off('peer-remove', this._boundPeerUpdate)
-      this.drive.db.core.off('upload', this._boundOnUpload)
-      this.drive.db.core.off('download', this._boundOnDownload)
-    }
+    this.drive.db.core.off('peer-add', this._boundPeerUpdate)
+    this.drive.db.core.off('peer-remove', this._boundPeerUpdate)
+    this.drive.db.core.off('upload', this._boundOnDbUpload)
+    this.drive.db.core.off('download', this._boundOnDbDownload)
 
     this.drive.monitors.delete(this)
   }
@@ -90,29 +91,34 @@ module.exports = class Monitor extends ReadyResource {
     }
   }
 
-  _onUpload(index, bytes, from) {
-    this._updateStats(this.uploadSpeedometer, this.uploadStats, index, bytes, from)
+  _onUpload(isDb, index, bytes, from) {
+    this._updateStats(this.uploadSpeedometer, this.uploadStats, index, bytes, from, isDb)
   }
 
-  _onDownload(index, bytes, from) {
-    this._updateStats(this.downloadSpeedometer, this.downloadStats, index, bytes, from)
+  _onDownload(isDb, index, bytes, from) {
+    this._updateStats(this.downloadSpeedometer, this.downloadStats, index, bytes, from, isDb)
   }
 
   _updatePeers() {
     this.uploadStats.peers = this.downloadStats.peers = this.peers = this.blobs.core.peers.length
   }
 
-  _updateStats(speed, stats, index, bytes, from) {
+  _updateStats(speed, stats, index, bytes, from, isDb) {
     if (this.closing) return
-    if (this.entry && !isWithinRange(index, this.entry)) return
+    if (!isDb && this.entry && !isWithinRange(index, this.entry)) return
 
     if (!stats.startTime) stats.startTime = Date.now()
 
     stats.speed = speed(bytes)
-    stats.blocks++
+
+    if (!isDb) {
+      // only tracking blob blocks
+      stats.blocks++
+    }
+
     stats.monitoringBytes += bytes
     stats.totalBytes += bytes
-    // NOTE: you should not rely on the percentage until the monitor is initialized with the local state of the file
+    stats[isDb ? 'dbBytes' : 'blobBytes'] += bytes
     stats.percentage = toFixed((stats.blocks / stats.targetBlocks) * 100)
 
     this.emit('update')

--- a/test.js
+++ b/test.js
@@ -1783,7 +1783,7 @@ test('download can be destroyed', async (t) => {
 })
 
 test('upload/download can be monitored', async (t) => {
-  t.plan(16)
+  t.plan(18)
   const { corestore, drive, swarm, mirror } = await testenv(t)
   swarm.on('connection', (conn) => corestore.replicate(conn))
   swarm.join(drive.discoveryKey, { server: true, client: false })
@@ -1826,12 +1826,20 @@ test('upload/download can be monitored', async (t) => {
 
   await mirror.drive.get(file)
 
-  t.is(uploadMonitor.uploadStats.monitoringBytes, bytes)
-  t.is(downloadMonitor.downloadStats.monitoringBytes, bytes)
+  t.is(uploadMonitor.uploadStats.blobBytes, bytes)
+  t.is(downloadMonitor.downloadStats.blobBytes, bytes)
+  t.is(
+    uploadMonitor.uploadStats.totalBytes,
+    uploadMonitor.uploadStats.dbBytes + uploadMonitor.uploadStats.blobBytes
+  )
+  t.is(
+    downloadMonitor.downloadStats.totalBytes,
+    downloadMonitor.downloadStats.dbBytes + downloadMonitor.downloadStats.blobBytes
+  )
+  t.is(downloadMonitor.downloadStats.percentage, 100)
+  t.is(uploadMonitor.uploadStats.percentage, 100)
   t.is(uploadMonitor.uploadStats.blocks, uploadMonitor.uploadStats.targetBlocks)
   t.is(downloadMonitor.downloadStats.blocks, downloadMonitor.downloadStats.targetBlocks)
-  t.is(uploadMonitor.uploadStats.percentage, 100)
-  t.is(downloadMonitor.downloadStats.percentage, 100)
   t.is(uploadMonitor.uploadSpeed(), uploadMonitor.uploadStats.speed)
   t.is(downloadMonitor.downloadSpeed(), downloadMonitor.downloadStats.speed)
   t.ok(uploadUpdates >= 2, 'upload should emit multiple update events')
@@ -1879,7 +1887,14 @@ test('monitor range download', async (t) => {
   t.is(monitor.downloadStats.peers, 1)
   t.ok(monitor.downloadStats.speed > 0)
   t.ok(monitor.downloadStats.blocks > 0)
-  t.ok(monitor.downloadStats.totalBytes, 3072)
+  t.is(monitor.downloadStats.blobBytes, 3072)
+  t.ok(monitor.downloadStats.dbBytes > 0)
+  t.ok(monitor.downloadStats.totalBytes >= 3072)
+  t.is(
+    monitor.downloadStats.totalBytes,
+    monitor.downloadStats.dbBytes + monitor.downloadStats.blobBytes
+  )
+  t.ok(monitor.downloadStats.percentage, 100)
 })
 
 test('dedup mode', async (t) => {


### PR DESCRIPTION
1. Fixed a bug with monitoring where the upload / download byte totals would sometimes inflate counts due to a race with the db preload. 
2. Enhanced the monitoring API to provide separate db and blob bytes