### PR TITLE
Fix download

### DIFF
--- a/index.js
+++ b/index.js
@@ -484,16 +484,16 @@ module.exports = class Hyperdrive extends ReadyResource {
     const blobs = await this.getBlobs()
     const entry = !path || path.endsWith('/') ? null : await this.entry(path)
     if (entry) {
-      const b = entry.value.blob
-      if (!b) return false
-      return await blobs.core.has(b.blockOffset, b.blockOffset + b.blockLength)
+      const blob = entry.value.blob
+      if (!blob) return false
+      return await this._hasEntry(blobs, blob)
     }
     let isDir = false
     for await (const entry of this.list(path)) {
       isDir = true
-      const b = entry.value.blob
-      if (!b) continue
-      const has = await blobs.core.has(b.blockOffset, b.blockOffset + b.blockLength)
+      const blob = entry.value.blob
+      if (!blob) continue
+      const has = await this._hasEntry(blobs, blob)
       if (!has) return false
     }
     return isDir
@@ -656,6 +656,19 @@ module.exports = class Hyperdrive extends ReadyResource {
         ondrain = null
         cb(err)
       }
+    }
+  }
+
+  async _hasEntry(blobs, blob) {
+    if (blob.blockMap) {
+      const map = await blobs.getBlockMap(blob)
+      for (const block of map.blocks) {
+        const has = await blobs.core.has(block.index)
+        if (!has) return false
+      }
+      return true
+    } else {
+      return await blobs.core.has(blob.blockOffset, blob.blockOffset + blob.blockLength)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -441,10 +441,10 @@ module.exports = class Hyperdrive extends ReadyResource {
 
     for await (const entry of this.diff(length, folder, opts)) {
       if (!entry.left) continue
-      const b = entry.left.value.blob
-      if (!b) continue
+      const blob = entry.left.value.blob
+      if (!blob) continue
       const blobs = await this.getBlobs()
-      dls.push(blobs.core.download({ start: b.blockOffset, length: b.blockLength }))
+      dls.push(await Download.downloadEntry(blobs, blob))
     }
 
     return new Download(this, null, { downloads: dls })

--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ module.exports = class Hyperdrive extends ReadyResource {
     if (entry) {
       const blob = entry.value.blob
       if (!blob) return false
-      return await this._hasEntry(blobs, blob)
+      return this._hasEntry(blobs, blob)
     }
     let isDir = false
     for await (const entry of this.list(path)) {
@@ -668,7 +668,7 @@ module.exports = class Hyperdrive extends ReadyResource {
       }
       return true
     } else {
-      return await blobs.core.has(blob.blockOffset, blob.blockOffset + blob.blockLength)
+      return blobs.core.has(blob.blockOffset, blob.blockOffset + blob.blockLength)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -441,10 +441,10 @@ module.exports = class Hyperdrive extends ReadyResource {
 
     for await (const entry of this.diff(length, folder, opts)) {
       if (!entry.left) continue
-      const blob = entry.left.value.blob
-      if (!blob) continue
+      const b = entry.left.value.blob
+      if (!b) continue
       const blobs = await this.getBlobs()
-      dls.push(await Download.downloadEntry(blobs, blob))
+      dls.push(blobs.core.download({ start: b.blockOffset, length: b.blockLength }))
     }
 
     return new Download(this, null, { downloads: dls })

--- a/index.js
+++ b/index.js
@@ -661,6 +661,9 @@ module.exports = class Hyperdrive extends ReadyResource {
 
   async _hasEntry(blobs, blob) {
     if (blob.blockMap) {
+      const hasMap = await blobs.core.has(blob.blockOffset, blob.blockOffset + blob.blockLength)
+      if (!hasMap) return false
+
       const map = await blobs.getBlockMap(blob)
       for (const block of map.blocks) {
         const has = await blobs.core.has(block.index)

--- a/lib/download.js
+++ b/lib/download.js
@@ -22,9 +22,9 @@ module.exports = class Download extends ReadyResource {
         : await drive.entry(this.folder, this.options)
 
     if (entry) {
-      const b = entry.value.blob
-      if (!b) return
-      const download = await this._downloadEntry(blobs, b)
+      const blob = entry.value.blob
+      if (!blob) return
+      const download = await this._downloadEntry(blobs, blob)
       this.downloads.push(download)
       return
     }

--- a/lib/download.js
+++ b/lib/download.js
@@ -27,10 +27,12 @@ module.exports = class Download extends ReadyResource {
       const blob = entry.value.blob
       if (!blob) return
 
-      const mapDownload = await this._cancellableDownload(
-        this.constructor.downloadEntryMap(blobs, blob)
-      )
-      if (!mapDownload) return
+if (blob.blockMap) {
+  const mapDownload = await this._cancellableDownload(
+    this.constructor.downloadEntryMap(blobs, blob)
+  )
+  if (!mapDownload) return
+}
 
       const download = await this.constructor.downloadEntry(blobs, blob)
       this.downloads.push(download)

--- a/lib/download.js
+++ b/lib/download.js
@@ -27,12 +27,12 @@ module.exports = class Download extends ReadyResource {
       const blob = entry.value.blob
       if (!blob) return
 
-if (blob.blockMap) {
-  const mapDownload = await this._cancellableDownload(
-    this.constructor.downloadEntryMap(blobs, blob)
-  )
-  if (!mapDownload) return
-}
+      if (blob.blockMap) {
+        const mapDownload = await this._cancellableDownload(
+          this.constructor.downloadEntryMap(blobs, blob)
+        )
+        if (!mapDownload) return
+      }
 
       const download = await this.constructor.downloadEntry(blobs, blob)
       this.downloads.push(download)

--- a/lib/download.js
+++ b/lib/download.js
@@ -56,7 +56,7 @@ module.exports = class Download extends ReadyResource {
       }
 
       const results = await Promise.all(maps.map((m) => this._cancellableDownload(m)))
-      if (results.includes(false)) return // if true, it means the Download got cancelled
+      if (results.includes(false)) return
 
       for (const entry of entries) {
         const blob = entry.value.blob
@@ -72,7 +72,7 @@ module.exports = class Download extends ReadyResource {
 
   static async downloadEntry(blobs, blob) {
     if (blob.blockMap) {
-      const map = await blobs.getBlockMap(blob) // always called after downloadEntryMap, so its non-blocking
+      const map = await blobs.getBlockMap(blob)
       const blocks = []
       for (const block of map.blocks) blocks.push(block.index)
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -8,7 +8,9 @@ module.exports = class Download extends ReadyResource {
     this.folder = folder
     this.options = options || {}
     this.downloads = this.options.downloads || []
-    this.destroyed = false
+    this._cancelled = new Promise((resolve) => {
+      this._cancel = resolve
+    })
     this.ready().catch(noop)
   }
 
@@ -24,6 +26,12 @@ module.exports = class Download extends ReadyResource {
     if (entry) {
       const blob = entry.value.blob
       if (!blob) return
+
+      const mapDownload = await this._cancellableDownload(
+        this.constructor.downloadEntryMap(blobs, blob)
+      )
+      if (!mapDownload) return
+
       const download = await this.constructor.downloadEntry(blobs, blob)
       this.downloads.push(download)
       return
@@ -47,7 +55,8 @@ module.exports = class Download extends ReadyResource {
         entries.push(entry) // cache entries
       }
 
-      await Promise.all(maps.map((m) => m.done()))
+      const results = await Promise.all(maps.map((m) => this._cancellableDownload(m)))
+      if (results.includes(false)) return // if true, it means the Download got cancelled
 
       for (const entry of entries) {
         const blob = entry.value.blob
@@ -57,11 +66,13 @@ module.exports = class Download extends ReadyResource {
     }
   }
 
+  static downloadEntryMap(blobs, blob) {
+    return blobs.core.download({ start: blob.blockOffset, length: blob.blockLength })
+  }
+
   static async downloadEntry(blobs, blob) {
     if (blob.blockMap) {
-      const map = await blobs.getBlockMap(blob)
-      if (!map) return null
-
+      const map = await blobs.getBlockMap(blob) // always called after downloadEntryMap, so its non-blocking
       const blocks = []
       for (const block of map.blocks) blocks.push(block.index)
 
@@ -78,6 +89,16 @@ module.exports = class Download extends ReadyResource {
     }
   }
 
+  async _cancellableDownload(download) {
+    return Promise.race([
+      download.done().then(() => true),
+      this._cancelled.then(() => {
+        download.destroy()
+        return false
+      })
+    ])
+  }
+
   _close() {
     for (const d of this.downloads) {
       d.destroy()
@@ -86,6 +107,7 @@ module.exports = class Download extends ReadyResource {
 
   destroy() {
     this.destroyed = true
+    this._cancel()
     this._safeBackgroundDestroy()
   }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -14,6 +14,8 @@ module.exports = class Download extends ReadyResource {
 
   async _open() {
     const drive = this.drive
+    const blobs = await drive.getBlobs()
+
     const entry =
       !this.folder || this.folder.endsWith('/')
         ? null
@@ -22,11 +24,7 @@ module.exports = class Download extends ReadyResource {
     if (entry) {
       const b = entry.value.blob
       if (!b) return
-      const blobs = await drive.getBlobs()
-      const download = blobs.core.download({
-        start: b.blockOffset,
-        length: b.blockLength
-      })
+      const download = await this._downloadEntry(blobs, b)
       this.downloads.push(download)
       return
     }
@@ -38,13 +36,45 @@ module.exports = class Download extends ReadyResource {
         // ignore
       }
 
+      const maps = []
+      const entries = []
       for await (const entry of drive.list(this.folder, this.options)) {
-        const b = entry.value.blob
-        if (!b) continue
-
-        const blobs = await drive.getBlobs()
-        this.downloads.push(blobs.core.download({ start: b.blockOffset, length: b.blockLength }))
+        const blob = entry.value.blob
+        if (!blob) continue
+        if (blob.blockMap && blob.blockLength) {
+          maps.push(blobs.core.download({ start: blob.blockOffset, length: blob.blockLength }))
+        }
+        entries.push(entry) // cache entries
       }
+
+      await Promise.all(maps.map((m) => m.done()))
+
+      for (const entry of entries) {
+        const blob = entry.value.blob
+        const download = await this._downloadEntry(blobs, blob)
+        this.downloads.push(download)
+      }
+    }
+  }
+
+  async _downloadEntry(blobs, blob) {
+    if (blob.blockMap) {
+      const map = await blobs.getBlockMap(blob)
+      if (!map) return null
+
+      const blocks = []
+      for (const block of map.blocks) blocks.push(block.index)
+
+      const download = blobs.core.download({ blocks })
+      await download.ready()
+      return download
+    } else {
+      const download = blobs.core.download({
+        start: blob.blockOffset,
+        length: blob.blockLength
+      })
+      await download.ready()
+      return download
     }
   }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -24,7 +24,7 @@ module.exports = class Download extends ReadyResource {
     if (entry) {
       const blob = entry.value.blob
       if (!blob) return
-      const download = await this._downloadEntry(blobs, blob)
+      const download = await this.constructor.downloadEntry(blobs, blob)
       this.downloads.push(download)
       return
     }
@@ -51,13 +51,13 @@ module.exports = class Download extends ReadyResource {
 
       for (const entry of entries) {
         const blob = entry.value.blob
-        const download = await this._downloadEntry(blobs, blob)
+        const download = await this.constructor.downloadEntry(blobs, blob)
         this.downloads.push(download)
       }
     }
   }
 
-  async _downloadEntry(blobs, blob) {
+  static async downloadEntry(blobs, blob) {
     if (blob.blockMap) {
       const map = await blobs.getBlockMap(blob)
       if (!map) return null

--- a/test.js
+++ b/test.js
@@ -919,6 +919,32 @@ test('drive.has(path)', async (t) => {
   t.ok(await mirror.drive.has('/parent/sibling/grandchild1'))
 })
 
+test('drive.has dedup entry is false after getting the blockMap', async (t) => {
+  t.plan(1)
+  const { corestore, drive, swarm, mirror } = await testenv(t)
+  swarm.on('connection', (conn) => corestore.replicate(conn))
+  swarm.join(drive.discoveryKey, { server: true, client: false })
+  await swarm.flush()
+
+  mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
+  mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
+  await mirror.swarm.flush()
+
+  const ws = await drive.createWriteStream('/entry', { dedup: true })
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.end()
+
+  await ensureDbLength(mirror.drive, drive.version)
+  await mirror.drive.entry('/entry')
+
+  await mirror.drive.getBlobs()
+  await mirror.drive.blobs.core.get(1) // get map block
+
+  t.is(await mirror.drive.has('/entry'), false)
+})
+
 test('drive.batch() & drive.flush()', async (t) => {
   const { drive } = await testenv(t)
 

--- a/test.js
+++ b/test.js
@@ -816,6 +816,38 @@ test('drive.downloadDiff(version, folder, [options])', async (t) => {
   t.is(blobscount, blobstelem.count)
 })
 
+test('dedup download can be destroyed while block map is unavailable', async (t) => {
+  t.plan(1)
+
+  const { corestore, drive, mirror } = await testenv(t)
+
+  const s1 = corestore.replicate(true)
+  const s2 = mirror.corestore.replicate(false)
+  s1.pipe(s2).pipe(s1)
+
+  const ws = drive.createWriteStream('/entry', { dedup: true })
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.end()
+
+  await new Promise((resolve, reject) => {
+    ws.once('error', reject)
+    ws.once('finish', resolve)
+  })
+
+  await ensureDbLength(mirror.drive, drive.version)
+  await mirror.drive.entry('/entry')
+
+  s1.destroy()
+  s2.destroy()
+
+  const download = mirror.drive.download('/entry')
+  download.destroy()
+
+  await download.close()
+  t.pass('download closed')
+})
+
 test('drive.downloadDiff dedup entry', async (t) => {
   t.plan(2)
   const { corestore, drive, swarm, mirror } = await testenv(t)

--- a/test.js
+++ b/test.js
@@ -992,7 +992,7 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   ws.write(Buffer.alloc(1024))
   ws.end()
 
-  await new Promise((resolve) => setTimeout(resolve, 100))
+  await once(ws, 'finish')
 
   await ensureDbLength(mirror.drive, drive.version)
   const entry = await mirror.drive.entry('/entry')

--- a/test.js
+++ b/test.js
@@ -848,6 +848,30 @@ test('dedup download can be destroyed while block map is unavailable', async (t)
   t.pass('download closed')
 })
 
+test('download can be destroyed before _open completes (folder)', async (t) => {
+  t.plan(1)
+  const { corestore, drive, mirror } = await testenv(t)
+
+  const s1 = corestore.replicate(true)
+  const s2 = mirror.corestore.replicate(false)
+  s1.pipe(s2).pipe(s1)
+
+  await drive.put('/folder/a', Buffer.alloc(1024))
+  await drive.put('/folder/b', Buffer.alloc(1024))
+
+  await ensureDbLength(mirror.drive, drive.version)
+  await mirror.drive.entry('/folder/a')
+
+  s1.destroy()
+  s2.destroy()
+
+  const download = mirror.drive.download('/folder')
+  download.destroy()
+  await download.close()
+
+  t.pass('folder download closed cleanly')
+})
+
 test('drive.downloadDiff dedup entry', async (t) => {
   t.plan(2)
   const { corestore, drive, swarm, mirror } = await testenv(t)

--- a/test.js
+++ b/test.js
@@ -945,6 +945,54 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   t.absent(await mirror.drive.has('/entry'), 'has() is false w/ map, but w/o blocks')
 })
 
+test('drive.has dedup entry does not download block map', async (t) => {
+  t.plan(3)
+
+  const { corestore, drive, mirror } = await testenv(t)
+
+  const s1 = corestore.replicate(true)
+  const s2 = mirror.corestore.replicate(false)
+  s1.pipe(s2).pipe(s1)
+
+  t.teardown(() => {
+    s1.destroy()
+    s2.destroy()
+  })
+
+  const ws = drive.createWriteStream('/entry', { dedup: true })
+  const done = new Promise((resolve, reject) => {
+    ws.once('error', reject)
+    ws.once('finish', resolve)
+  })
+
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.end()
+  await done
+
+  await ensureDbLength(mirror.drive, drive.version)
+
+  const entry = await mirror.drive.entry('/entry')
+  const blob = entry.value.blob
+  const blobs = await mirror.drive.getBlobs()
+
+  t.absent(
+    await blobs.core.has(blob.blockOffset, blob.blockOffset + blob.blockLength),
+    'sanity: block map is not local before has()'
+  )
+
+  let downloads = 0
+  blobs.core.on('download', ondownload)
+  t.teardown(() => blobs.core.off('download', ondownload))
+
+  t.absent(await mirror.drive.has('/entry'), 'entry data is not local')
+  t.is(downloads, 0, 'has() should not download while checking local state')
+
+  function ondownload() {
+    downloads++
+  }
+})
+
 test('drive.batch() & drive.flush()', async (t) => {
   const { drive } = await testenv(t)
 

--- a/test.js
+++ b/test.js
@@ -872,39 +872,6 @@ test('download can be destroyed before _open completes (folder)', async (t) => {
   t.pass('folder download closed cleanly')
 })
 
-test('drive.downloadDiff dedup entry', async (t) => {
-  t.plan(2)
-  const { corestore, drive, swarm, mirror } = await testenv(t)
-  swarm.on('connection', (conn) => corestore.replicate(conn))
-  swarm.join(drive.discoveryKey, { server: true, client: false })
-  await swarm.flush()
-  mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
-  mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
-  await mirror.swarm.flush()
-
-  const version = drive.version
-
-  const ws = drive.createWriteStream('/folder/entry', { dedup: true })
-  ws.write(Buffer.alloc(1024))
-  ws.write(Buffer.alloc(1024))
-  ws.write(Buffer.alloc(1024))
-  ws.end()
-
-  await new Promise((resolve) => ws.once('finish', resolve))
-  await ensureDbLength(mirror.drive, drive.version)
-
-  const download = await mirror.drive.downloadDiff(version, '/folder')
-  await download.done()
-
-  const mirrorBlobs = await mirror.drive.getBlobs()
-  const driveBlobs = await drive.getBlobs()
-  const mirrorBlobsHash = await mirrorBlobs.core.treeHash()
-  const driveBlobsHash = await driveBlobs.core.treeHash()
-
-  t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
-  t.alike(mirrorBlobsHash, driveBlobsHash, 'blob hashes match')
-})
-
 test('drive.download dedup entry', async (t) => {
   t.plan(2)
   const { corestore, drive, swarm, mirror } = await testenv(t)

--- a/test.js
+++ b/test.js
@@ -816,6 +816,70 @@ test('drive.downloadDiff(version, folder, [options])', async (t) => {
   t.is(blobscount, blobstelem.count)
 })
 
+test('drive.download dedup entry', async (t) => {
+  t.plan(2)
+  const { corestore, drive, swarm, mirror } = await testenv(t)
+  swarm.on('connection', (conn) => corestore.replicate(conn))
+  swarm.join(drive.discoveryKey, { server: true, client: false })
+  await swarm.flush()
+
+  mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
+  mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
+  await mirror.swarm.flush()
+
+  const ws = await drive.createWriteStream('/entry', { dedup: true })
+  ws.write(Buffer.alloc(1024))
+  ws.end()
+
+  await ensureDbLength(mirror.drive, drive.version)
+
+  const download = await mirror.drive.download('/entry')
+  await download.done()
+
+  const mirrorBlobs = await mirror.drive.getBlobs()
+  const driveBlobs = await drive.getBlobs()
+
+  const mirrorBlobsHash = await mirrorBlobs.core.treeHash()
+  const driveBlobsHash = await driveBlobs.core.treeHash()
+
+  t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
+  t.is(mirrorBlobsHash.toString('hex'), driveBlobsHash.toString('hex'))
+})
+
+test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
+  t.plan(2)
+  const { corestore, drive, swarm, mirror } = await testenv(t)
+  swarm.on('connection', (conn) => corestore.replicate(conn))
+  swarm.join(drive.discoveryKey, { server: true, client: false })
+  await swarm.flush()
+
+  mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
+  mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
+  await mirror.swarm.flush()
+
+  {
+    const ws = await drive.createWriteStream('/folder/entry', { dedup: true })
+    ws.write(Buffer.alloc(1024))
+    ws.end()
+  }
+
+  await drive.put('/folder/entry-b', Buffer.from('hello world'))
+
+  await ensureDbLength(mirror.drive, drive.version)
+
+  const download = await mirror.drive.download('/folder')
+  await download.done()
+
+  const mirrorBlobs = await mirror.drive.getBlobs()
+  const driveBlobs = await drive.getBlobs()
+
+  const mirrorBlobsHash = await mirrorBlobs.core.treeHash()
+  const driveBlobsHash = await driveBlobs.core.treeHash()
+
+  t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
+  t.is(mirrorBlobsHash.toString('hex'), driveBlobsHash.toString('hex'))
+})
+
 test('drive.has(path)', async (t) => {
   t.plan(8)
   const { corestore, drive, swarm, mirror } = await testenv(t)

--- a/test.js
+++ b/test.js
@@ -992,6 +992,8 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   ws.write(Buffer.alloc(1024))
   ws.end()
 
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
   await ensureDbLength(mirror.drive, drive.version)
   const entry = await mirror.drive.entry('/entry')
 

--- a/test.js
+++ b/test.js
@@ -117,7 +117,7 @@ test('drive.createWriteStream(path) and drive.createReadStream(path)', async (t)
       drive.createReadStream(__filename),
       new Writable({
         write(data, cb) {
-          if (bndlbuf) bndlbuf = b4a.concat(bndlbuf, data)
+          if (bndlbuf) bndlbuf = b4a.concat([bndlbuf, data])
           else bndlbuf = data
           return cb(null)
         }
@@ -814,6 +814,39 @@ test('drive.downloadDiff(version, folder, [options])', async (t) => {
 
   t.is(filescount, filestelem.count)
   t.is(blobscount, blobstelem.count)
+})
+
+test('drive.downloadDiff dedup entry', async (t) => {
+  t.plan(2)
+  const { corestore, drive, swarm, mirror } = await testenv(t)
+  swarm.on('connection', (conn) => corestore.replicate(conn))
+  swarm.join(drive.discoveryKey, { server: true, client: false })
+  await swarm.flush()
+  mirror.swarm.on('connection', (conn) => mirror.corestore.replicate(conn))
+  mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
+  await mirror.swarm.flush()
+
+  const version = drive.version
+
+  const ws = drive.createWriteStream('/folder/entry', { dedup: true })
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.write(Buffer.alloc(1024))
+  ws.end()
+
+  await new Promise((resolve) => ws.once('finish', resolve))
+  await ensureDbLength(mirror.drive, drive.version)
+
+  const download = await mirror.drive.downloadDiff(version, '/folder')
+  await download.done()
+
+  const mirrorBlobs = await mirror.drive.getBlobs()
+  const driveBlobs = await drive.getBlobs()
+  const mirrorBlobsHash = await mirrorBlobs.core.treeHash()
+  const driveBlobsHash = await driveBlobs.core.treeHash()
+
+  t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
+  t.alike(mirrorBlobsHash, driveBlobsHash, 'blob hashes match')
 })
 
 test('drive.download dedup entry', async (t) => {

--- a/test.js
+++ b/test.js
@@ -993,10 +993,10 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   ws.end()
 
   await ensureDbLength(mirror.drive, drive.version)
-  await mirror.drive.entry('/entry')
+  const entry = await mirror.drive.entry('/entry')
 
   await mirror.drive.getBlobs()
-  await mirror.drive.blobs.core.get(1) // get map block
+  await mirror.drive.blobs.core.get(entry.value.blob.blockOffset) // get map block
 
   t.absent(await mirror.drive.has('/entry'), 'has() is false w/ map, but w/o blocks')
 })

--- a/test.js
+++ b/test.js
@@ -887,6 +887,8 @@ test('drive.download dedup entry', async (t) => {
   ws.write(Buffer.alloc(1024))
   ws.end()
 
+  await once(ws, 'finish')
+
   await ensureDbLength(mirror.drive, drive.version)
 
   const download = mirror.drive.download('/entry')
@@ -917,6 +919,7 @@ test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
     const ws = drive.createWriteStream('/folder/entry', { dedup: true })
     ws.write(Buffer.alloc(1024))
     ws.end()
+    await once(ws, 'finish')
   }
 
   await drive.put('/folder/entry-b', Buffer.from('hello world'))

--- a/test.js
+++ b/test.js
@@ -827,13 +827,13 @@ test('drive.download dedup entry', async (t) => {
   mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
   await mirror.swarm.flush()
 
-  const ws = await drive.createWriteStream('/entry', { dedup: true })
+  const ws = drive.createWriteStream('/entry', { dedup: true })
   ws.write(Buffer.alloc(1024))
   ws.end()
 
   await ensureDbLength(mirror.drive, drive.version)
 
-  const download = await mirror.drive.download('/entry')
+  const download = mirror.drive.download('/entry')
   await download.done()
 
   const mirrorBlobs = await mirror.drive.getBlobs()
@@ -843,7 +843,7 @@ test('drive.download dedup entry', async (t) => {
   const driveBlobsHash = await driveBlobs.core.treeHash()
 
   t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
-  t.is(mirrorBlobsHash.toString('hex'), driveBlobsHash.toString('hex'))
+  t.alike(mirrorBlobsHash, driveBlobsHash, 'blob hashes match')
 })
 
 test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
@@ -858,7 +858,7 @@ test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
   await mirror.swarm.flush()
 
   {
-    const ws = await drive.createWriteStream('/folder/entry', { dedup: true })
+    const ws = drive.createWriteStream('/folder/entry', { dedup: true })
     ws.write(Buffer.alloc(1024))
     ws.end()
   }
@@ -867,7 +867,7 @@ test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
 
   await ensureDbLength(mirror.drive, drive.version)
 
-  const download = await mirror.drive.download('/folder')
+  const download = mirror.drive.download('/folder')
   await download.done()
 
   const mirrorBlobs = await mirror.drive.getBlobs()
@@ -877,7 +877,7 @@ test('drive.download folder mixed dedup: true and dedup: false', async (t) => {
   const driveBlobsHash = await driveBlobs.core.treeHash()
 
   t.is(mirrorBlobs.core.contiguousLength, driveBlobs.core.contiguousLength)
-  t.is(mirrorBlobsHash.toString('hex'), driveBlobsHash.toString('hex'))
+  t.alike(mirrorBlobsHash, driveBlobsHash, 'blob hashes match')
 })
 
 test('drive.has(path)', async (t) => {
@@ -930,7 +930,7 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   mirror.swarm.join(drive.discoveryKey, { server: false, client: true })
   await mirror.swarm.flush()
 
-  const ws = await drive.createWriteStream('/entry', { dedup: true })
+  const ws = drive.createWriteStream('/entry', { dedup: true })
   ws.write(Buffer.alloc(1024))
   ws.write(Buffer.alloc(1024))
   ws.write(Buffer.alloc(1024))
@@ -942,7 +942,7 @@ test('drive.has dedup entry is false after getting the blockMap', async (t) => {
   await mirror.drive.getBlobs()
   await mirror.drive.blobs.core.get(1) // get map block
 
-  t.is(await mirror.drive.has('/entry'), false)
+  t.absent(await mirror.drive.has('/entry'), 'has() is false w/ map, but w/o blocks')
 })
 
 test('drive.batch() & drive.flush()', async (t) => {


### PR DESCRIPTION
The Download class was broken for entries written with dedup: true. Dedup entries store blobs using a block map (an index of non-contiguous blocks) rather than a contiguous blockOffset/blockLength range. The previous code always downloaded using { start, length }, which is incorrect for dedup entries — it would request the wrong range from the blobs core, causing downloads to silently stall or fetch the wrong data.

The same bug affected has(), which also used the contiguous range form for all entries. Both are fixed via new _downloadEntry and _hasEntry helpers that branch on blob.blockMap, using resolved block indices for dedup entries and falling back to the range form otherwise. 

The same bug existed in downloadDiff. It manually constructed blob downloads using { start: b.blockOffset, length: b.blockLength }, always taking the contiguous range path and never handling dedup entries. 

